### PR TITLE
Separate .gitignore and .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,63 @@
-.gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# App
+eregs.db
+
+# Local frontend build
+frontend_build/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ target/
 
 # App
 eregs.db
+
+# Local frontend build
+frontend_build/
+compiled/


### PR DESCRIPTION
Make Git ignore compiled/ and frontend_build/ directories; split out .cfignore and make CloudFoundry ignore the frontend_build/ directory but not the compiled/ directory.