### PR TITLE
Remove text about SxS and interpretations from about page

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -8,7 +8,7 @@ REGCORE_DATABASES = dict(DATABASES)
 from regulations.settings.base import *
 REGSITE_APPS = tuple(INSTALLED_APPS)
 
-INSTALLED_APPS = ('atf_eregs',) + REGCORE_APPS + REGSITE_APPS
+INSTALLED_APPS = ('overextends', 'atf_eregs',) + REGCORE_APPS + REGSITE_APPS
 
 ROOT_URLCONF = 'atf_eregs.urls'
 

--- a/atf_eregs/templates/regulations/about.html
+++ b/atf_eregs/templates/regulations/about.html
@@ -1,0 +1,22 @@
+{% overextends "regulations/about.html" %}
+{% load static from staticfiles %}
+
+{% block about-related-info %}
+<section class="about-section group" id="related-info">
+    <div class="inner-wrap">
+    <h3>Related information</h3>
+
+    <div class="content-primary column-r">
+        <img src="{%static "regulations/img/related-01.png" %}" alt="eRegulations defined terms, linked references, and official interpretation screenshot">
+    </div>
+
+    <div class="content-secondary column-l">
+        <ol class="about-ol">
+            <li><strong>Defined terms</strong> are highlighted in the text and displayed in the right sidebar so you can keep your place.</li>
+            <li>References to other parts of the regulation are <strong>linked</strong>.</li>
+        </ol>
+    </div>
+
+</div>
+</section>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 anyjson
 django==1.8
 django-haystack
+django-overextends
 jsonschema
 lxml
 pyelasticsearch


### PR DESCRIPTION
As none of the ATF regs appear to have these features, we should avoid mentioning them about the about page.

Makes use of the `django-overextends` library to reuse most of the about template.

Resolves #45 