### PR TITLE
Settings and README update

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -58,6 +58,7 @@ target/
 
 # App
 eregs.db
+local_settings.py
 
 # Local frontend build
 frontend_build/

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ target/
 
 # App
 eregs.db
+local_settings.py
 
 # Local frontend build
 frontend_build/

--- a/README.md
+++ b/README.md
@@ -3,20 +3,44 @@ Container and styles for an ATF eRegs instance
 
 ## Local Development
 
-Use pip to download the required libraries:
+Use pip and npm to download the required libraries:
 
 ```bash
 $ pip install -r requirements.txt
+$ npm install -g grunt-cli bower
 ```
 
-Then initialize the database and run the server:
+Then initialize the database, build the frontend, and run the server:
 
 ```bash
 $ python manage.py migrate --fake-initial
+$ python manage.py compile_frontend
 $ python manage.py runserver
+```
+
+## Ports
+
+For the time being, this application, which cobbles together
+[regulations-core](https://github.com/18F/regulations-core) and
+[regulations-site](https://github.com/18F/regulations-site), makes HTTP calls
+to itself. The server therefore needs to know which port it is set up to
+listen on.
+
+We default to 8000, as that's the standard for django's `runserver`, but if
+you need to run on a different port, either export an environmental variable
+or create a local_settings.py as follows:
+
+```bash
+$ export VCAP_APP_PORT=1234
+```
+
+OR
+
+```bash
+$ echo "API_BASE = 'http://localhost:1234'" >> local_settings.py
 ```
 
 ## TODO
 
 * Database config
-* Port config
+* Search config

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ export VCAP_APP_PORT=1234
 OR
 
 ```bash
-$ echo "API_BASE = 'http://localhost:1234'" >> local_settings.py
+$ echo "API_BASE = 'http://localhost:1234/api/'" >> local_settings.py
 ```
 
 ## TODO

--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -16,3 +16,5 @@ DATABASES = REGCORE_DATABASES
 
 API_BASE = 'http://localhost:{}/api/'.format(
     os.environ.get('VCAP_APP_PORT', '8080'))
+
+STATICFILES_DIRS = ['compiled']

--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -15,6 +15,6 @@ ROOT_URLCONF = 'atf_eregs.urls'
 DATABASES = REGCORE_DATABASES
 
 API_BASE = 'http://localhost:{}/api/'.format(
-    os.environ.get('VCAP_APP_PORT', '8080'))
+    os.environ.get('VCAP_APP_PORT', '8000'))
 
 STATICFILES_DIRS = ['compiled']

--- a/atf_eregs/settings/dev.py
+++ b/atf_eregs/settings/dev.py
@@ -1,0 +1,6 @@
+from .base import *
+
+try:
+    from local_settings import *
+except ImportError:
+    pass

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "atf_eregs.settings.base")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "atf_eregs.settings.dev")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Depends on 18F/regulations-site#32

* Adds 'compiled' to the list of static directories to search for files
* Defaults the port the app looks at for reading from the API to 8000
* Allow a local_settings file to override `base`
* Update README