### PR TITLE
Style tweaks

### DIFF
--- a/atf_eregs/static/regulations/css/less/mixins.less
+++ b/atf_eregs/static/regulations/css/less/mixins.less
@@ -18,7 +18,7 @@ mixins.less contains any mixins or variables to be used throughout the LESS file
 @grey: #E6E7E9;
 @white: #FFFFFF;
 @red_orange: #D12124;
-@pacific: #50627a; //#0072CE; /* see more carrots */
+@pacific: #0072CE; /* see more carrots */
 @link_blue: #348dc9; /* blue used for link borders and search results */
 @light_neutral: #D7D2CB;
 @dark_gray: #797D81; /* dark border */

--- a/atf_eregs/static/regulations/css/less/mixins.less
+++ b/atf_eregs/static/regulations/css/less/mixins.less
@@ -74,12 +74,12 @@ mixins.less contains any mixins or variables to be used throughout the LESS file
 
 .avenir-next {
   font-family: "Work Sans",Arial,Helvetica,Verdana,Geneva,sans-serif;
-  font-weight: 500;
+  font-weight: 100;
 }
 
 .avenir-next-demi {
   font-family: "Work Sans",Arial,Helvetica,Verdana,Geneva,sans-serif;
-  font-weight: 500;
+  font-weight: 800;
 }
 
 /*

--- a/atf_eregs/static/regulations/css/less/module/about.less
+++ b/atf_eregs/static/regulations/css/less/module/about.less
@@ -1,0 +1,265 @@
+/*
+ About
+ ==========================================================================
+ about.less defines the visual appearance of the eRegulations about page
+ */
+
+/* about-content is the same as landing-content, these should be unified into one class */
+.about-content {
+    margin-top: 60px;
+    .avenir-next;
+
+    img {
+        max-width: 100%;
+    }
+
+    h3 {
+        margin: 0 0 30px 0;
+    }
+
+    // offset persistent header
+    .inner-wrap:before {
+        display: block;
+        content: "";
+        height: 60px;
+        margin-top: -60px;
+        visibility: hidden;
+    }
+}
+
+/*
+hero
+------------------
+*/
+
+.title-hero {
+    background-color: @hero_background;
+    color: @hero_text_color;
+    .border-bottom-light;
+
+    h2 {
+        font-size: 34px;
+        padding: 24px 0;
+        margin: 0;
+        .avenir-next;
+    }
+}
+
+.about-section {
+    border-bottom: 1px solid @medium_gray;
+    padding-bottom: 1em;
+}
+
+.about-section:last-child {
+    border-bottom: 0px;
+}
+
+/*
+layout
+-------------------
+*/
+
+
+.about-section {
+    padding: 4em 0;
+    .inner-wrap {
+        padding: 0 1em;
+    }
+}
+
+.easy-read {
+    margin-top: 4em;
+}
+
+/*
+dev well
+------------------
+*/
+
+
+.dev-well {
+
+    h4 {
+        .reset;
+    }
+
+    p {
+        .reset;
+        font-size: 0.875em;
+    }
+
+    .cf-icon-github {
+        float: left;
+        display: block;
+        height: 100px;
+        margin-right: 16px;
+        font-size: 1.5em;
+        color: @dark_gray;
+    }
+
+}
+
+/*
+snazzy ordered lists
+------------------
+*/
+
+
+.about-ol {
+    counter-reset: li;
+    list-style: none;
+    *list-style: decimal; /* use default numbering for IE6/7 */
+    position: relative;
+}
+
+.about-ol > li {
+    margin: 1em 0 3em 0;
+}
+
+.about-ol > li:last-child {
+    margin-bottom: 0;
+}
+
+.about-ol > li:before{
+    content: counter(li);
+    counter-increment: li;
+    background: @green;
+    color: #fff;
+    font-size: 12px;
+    position: absolute;
+    text-align: center;
+    left: -1em;
+    height: 20px;
+    width: 20px;
+    line-height: 20px;
+    border-radius: 20px;
+}
+
+/*
+custom styles
+------------------
+*/
+
+.easy-nav {
+    padding-left: 60px;
+    position: relative;
+}
+
+.icon-callout {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 46px;
+    height: 46px;
+    line-height: 46px;
+    border-radius: 4px;
+    text-align: center;
+    background: @bg_gray;
+    color: @80_gray;
+    font-size: 22px;
+}
+
+@media only screen and ( min-width: 780px ) {
+    .about-screenshot {
+        margin-bottom: -70px; /*align with border on larger screens */
+    }
+}
+
+.about-timeline {
+    margin-left: 20px;
+}
+
+.about-timeline:before {
+    font-family: 'CFPB Minicons';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    content: "\e642";
+    color: @green;
+    margin-left: -32px;
+    padding-right: 12px;
+    font-size: 18px;
+}
+
+.small-disclaimer {
+    display: block;
+    color: @80_gray;
+    line-height: 1.4;
+}
+
+
+/*
+Smaller Screen Styles
+======================
+*/
+
+@media only screen and ( max-width: 780px ) {
+
+    /*
+    less section padding
+    -------------------- */
+    .about-section {
+        padding: 2em 0;
+    }
+
+    .easy-read {
+        margin-top: 2em;
+    }
+
+
+    /*
+    hidden
+    ----------------- */
+    .responsive-img {
+        display: none;
+    }
+
+    /* Spacing
+    ----------------- */
+    .title-hero {
+        margin-bottom: 0;
+    }
+
+    .easy-nav {
+        margin-bottom: 2em;
+    }
+
+    .learn-more {
+        margin-top: -1em;
+    }
+
+    .about-ol {
+        margin-left: 1em;
+    }
+
+    .about-timeline {
+        padding-left: 1em;
+    }
+
+    /* styles
+    ------------------- */
+    .about-section {
+        border-bottom: 0px;
+    }
+
+}
+
+/*
+Smallest Screen Styles
+======================
+*/
+
+@media only screen and ( max-width: 460px ) {
+
+    .title-hero {
+        h2 {
+            font-size: 26px;
+            padding: 12px 0;
+        }
+    }
+
+}

--- a/atf_eregs/static/regulations/css/less/module/header.less
+++ b/atf_eregs/static/regulations/css/less/module/header.less
@@ -88,7 +88,7 @@
 
 .title a:hover,
 .title a:active {
-    color: @pacific;
+    color: @main_head_hover_color;
 }
 
 .sub-head {

--- a/atf_eregs/static/regulations/css/less/module/universal-landing.less
+++ b/atf_eregs/static/regulations/css/less/module/universal-landing.less
@@ -19,14 +19,17 @@
  =======
  the hero is the large graphic/information area
  */
-
-.hero {
+.title-hero {
     background-color: @hero_background;
     color: @hero_text_color;
     overflow: hidden;
     .avenir-next;
     .border-bottom-light;
 
+}
+
+.hero {
+    .title-hero;
     .inner-wrap {
         background: url(../img/hero.png) 96% -100% no-repeat;
     }

--- a/atf_eregs/static/regulations/css/less/module/universal-landing.less
+++ b/atf_eregs/static/regulations/css/less/module/universal-landing.less
@@ -26,6 +26,10 @@
     .avenir-next;
     .border-bottom-light;
 
+    a:link,
+    a:visited {
+      color: @pacific_light;
+    }
 }
 
 .hero {

--- a/atf_eregs/static/regulations/css/less/module/universal-landing.less
+++ b/atf_eregs/static/regulations/css/less/module/universal-landing.less
@@ -19,7 +19,7 @@
  =======
  the hero is the large graphic/information area
  */
-.title-hero {
+.hero {
     background-color: @hero_background;
     color: @hero_text_color;
     overflow: hidden;
@@ -30,10 +30,7 @@
     a:visited {
       color: @pacific_light;
     }
-}
 
-.hero {
-    .title-hero;
     .inner-wrap {
         background: url(../img/hero.png) 96% -100% no-repeat;
     }


### PR DESCRIPTION
1. Account for the hero text color on the "About" page
<img width="429" alt="screen shot 2015-09-24 at 5 47 34 pm" src="https://cloud.githubusercontent.com/assets/326918/10087815/5f00324a-62e4-11e5-921a-324c1b7d0ac6.png">
<img width="428" alt="screen shot 2015-09-24 at 5 47 51 pm" src="https://cloud.githubusercontent.com/assets/326918/10087821/69c0528c-62e4-11e5-97bd-a008dbb81666.png">

2. Change the default and bold font weights
<img width="676" alt="screen shot 2015-09-24 at 5 49 33 pm" src="https://cloud.githubusercontent.com/assets/326918/10087862/b0f74750-62e4-11e5-9480-3495fe8c7036.png">
<img width="669" alt="screen shot 2015-09-24 at 5 49 41 pm" src="https://cloud.githubusercontent.com/assets/326918/10087865/b5969ea0-62e4-11e5-8417-17e3627d8776.png">

3. Set the link color to a brighter blue, save in the header
<img width="1022" alt="screen shot 2015-09-24 at 5 51 18 pm" src="https://cloud.githubusercontent.com/assets/326918/10087936/1fbd3b54-62e5-11e5-839e-d066872b7a57.png">
<img width="1017" alt="screen shot 2015-09-24 at 5 51 45 pm" src="https://cloud.githubusercontent.com/assets/326918/10087939/26a2bafc-62e5-11e5-8018-9cae6f62d0c9.png">

<img width="1157" alt="screen shot 2015-09-24 at 5 51 31 pm" src="https://cloud.githubusercontent.com/assets/326918/10087949/32584290-62e5-11e5-90a6-6d52ea1068bc.png">
<img width="1157" alt="screen shot 2015-09-24 at 6 11 54 pm" src="https://cloud.githubusercontent.com/assets/326918/10088304/d1a0e83c-62e7-11e5-8187-2fb5fef00962.png">


Resolves #43 and #41