### PR TITLE
Squished table headers fix.

### DIFF
--- a/atf_eregs/static/regulations/css/less/typography.less
+++ b/atf_eregs/static/regulations/css/less/typography.less
@@ -392,6 +392,10 @@ The `<ol>` tag needs to have the appropriate list type applied
 ```
 */
 
+.main-content {
+    overflow-x:scroll;
+}
+
 .main-content ol, dfn, .stripped-marker {
   .avenir-next-demi;
 }
@@ -564,7 +568,7 @@ table {
     padding: 0;
     font-size: .75em;
     .avenir-next;
-    table-layout: fixed;
+    table-layout: auto;
     width: 100%;
 }
 


### PR DESCRIPTION
Changed table layout to auto to prevent table headers from being squished. Made the main content div scrollable horizontally to accommodate larger tables.