### PR TITLE
Tweak colors so that the mobile header looks okay

### DIFF
--- a/atf_eregs/static/regulations/css/less/module/header.less
+++ b/atf_eregs/static/regulations/css/less/module/header.less
@@ -261,6 +261,8 @@ BIG SCREENS
 tiny screens
 =============================================
 */
+@mobile_nav_bg: @green_midtone;   /* actually a navy */
+@mobile_nav_hl: @green;           /* actually a dark blue */
 
 @media only screen and ( max-width: 879px ) {
     .org-title {
@@ -295,7 +297,7 @@ tiny screens
         position: fixed;
         top: 60px;
         width: 100%;
-        background: @bg_gray;
+        background: @mobile_nav_bg;
         z-index: 999999;
     }
 
@@ -312,7 +314,7 @@ tiny screens
         a:hover,
         a:active,
         a:focus {
-            background: #E6E6E6;
+            background: @mobile_nav_hl;
         }
     }
 
@@ -327,7 +329,7 @@ tiny screens
     .mobile-nav-trigger:active,
     .mobile-nav-trigger:focus,
     .mobile-nav-trigger.open {
-        background-color: @bg_gray;
+        background-color: @mobile_nav_bg;
     }
 
     .title {


### PR DESCRIPTION
Was
<img width="828" alt="screen shot 2015-12-08 at 1 05 08 pm" src="https://cloud.githubusercontent.com/assets/326918/11663879/b0a8578c-9dac-11e5-8863-b99522d443f5.png">

Now
<img width="825" alt="screen shot 2015-12-08 at 1 05 33 pm" src="https://cloud.githubusercontent.com/assets/326918/11663886/b458be08-9dac-11e5-84bb-9375d39bfb51.png">

"About" is in hover state in both screenshots

Resolves #146 