### PR TITLE
Configure ATF layers

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -18,3 +18,19 @@ API_BASE = 'http://localhost:{}/api/'.format(
     os.environ.get('VCAP_APP_PORT', '8000'))
 
 STATICFILES_DIRS = ['compiled']
+
+DATA_LAYERS = (
+    'regulations.generator.layers.defined.DefinedLayer',
+    'regulations.generator.layers.definitions.DefinitionsLayer',
+    'regulations.generator.layers.formatting.FormattingLayer',
+    'regulations.generator.layers.internal_citation.InternalCitationLayer',
+    'regulations.generator.layers.key_terms.KeyTermsLayer',
+    'regulations.generator.layers.meta.MetaLayer',
+    'regulations.generator.layers.paragraph_markers.ParagraphMarkersLayer',
+    'regulations.generator.layers.toc_applier.TableOfContentsLayer',
+    'regulations.generator.layers.graphics.GraphicsLayer',
+)
+
+SIDEBARS = (
+    'regulations.generator.sidebar.help.Help',
+)


### PR DESCRIPTION
Removes SxS and interpretations, which aren't present in ATF regs

The sidebar config won't have an impact until 18f/regulations-site#59 is merged