### PR TITLE
Example of a regulation landing page with extra context

### DIFF
--- a/atf_eregs/templates/regulations/generic_landing.html
+++ b/atf_eregs/templates/regulations/generic_landing.html
@@ -8,13 +8,6 @@ like to provide a consistent disclaimer. Overextends tells django to use the
 {% block legal_disclaimer %}
 <h4 tabindex="0" class="important">Trust, but verify</h4>
 
-<p>The ATF’s eRegulations tool is an editorial compilation of material and not
-an official legal edition of the Code of Federal Regulations or the Federal
-Register. We have made every effort to ensure the material presented in this
-tool is accurate, but if you are relying on it for legal research you should
-consult the official editions of those sources to confirm your findings.
-Nothing in this tool binds ATF or creates any rights, benefits, or defenses,
-substantive or procedural, that are enforceable by any party in any
-manner.</p>
+<p><strong>Legal limitations of this tool:</strong> The ATF’s eRegulations tool is an editorial compilation of material and not an official legal edition of the <a href="https://www.archives.gov/federal-register/cfr/" class="external" target="_blank">Code of Federal Regulations</a> or the <a href="https://www.federalregister.gov/" class="external" target="_blank">Federal Register</a>. We have made every effort to ensure the material presented in this tool is accurate, but if you are relying on it for legal research you should <a href="http://www.ecfr.gov/cgi-bin/ECFR?page=userinfo" class="external" target="_blank">consult the official editions of those sources</a> to confirm your findings. Nothing in this tool binds ATF or creates any rights, benefits, or defenses, substantive or procedural, that are enforceable by any party in any manner.</p>
 {% endblock %}
 

--- a/atf_eregs/templates/regulations/generic_landing.html
+++ b/atf_eregs/templates/regulations/generic_landing.html
@@ -8,6 +8,19 @@ like to provide a consistent disclaimer. Overextends tells django to use the
 {% block legal_disclaimer %}
 <h4 tabindex="0" class="important">Trust, but verify</h4>
 
-<p><strong>Legal limitations of this tool:</strong> The ATF’s eRegulations tool is an editorial compilation of material and not an official legal edition of the <a href="https://www.archives.gov/federal-register/cfr/" class="external" target="_blank">Code of Federal Regulations</a> or the <a href="https://www.federalregister.gov/" class="external" target="_blank">Federal Register</a>. We have made every effort to ensure the material presented in this tool is accurate, but if you are relying on it for legal research you should <a href="http://www.ecfr.gov/cgi-bin/ECFR?page=userinfo" class="external" target="_blank">consult the official editions of those sources</a> to confirm your findings. Nothing in this tool binds ATF or creates any rights, benefits, or defenses, substantive or procedural, that are enforceable by any party in any manner.</p>
+<p><strong>Legal limitations of this tool:</strong> The ATF’s eRegulations tool
+is an editorial compilation of material and not an official legal edition of
+the <a href="https://www.archives.gov/federal-register/cfr/" class="external"
+target="_blank">Code of Federal Regulations</a> or the <a
+href="https://www.federalregister.gov/" class="external"
+target="_blank">Federal Register</a>. We have made every effort to ensure the
+material presented in this tool is accurate, but if you are relying on it for
+legal research you should <a
+href="http://www.ecfr.gov/cgi-bin/ECFR?page=userinfo" class="external"
+target="_blank">consult the official editions of those sources</a> to confirm
+your findings. Nothing in this tool binds ATF or creates any rights, benefits,
+or defenses, substantive or procedural, that are enforceable by any party in
+any manner.</p>
+
 {% endblock %}
 

--- a/atf_eregs/templates/regulations/landing_447.html
+++ b/atf_eregs/templates/regulations/landing_447.html
@@ -14,8 +14,6 @@
   <li><a href="/447-53/2015-12992#447-53-a" class="citation internal">Exemptions to import requirements</a></li>
   <li>Penalties for <a href="/447-61/2015-12992#447-61" class="citation internal">unlawful importation</a> and <a href="/447-62/2015-12992#447-62" class="citation internal">false statements or concealment of facts</a>; <a href="/447-63/2015-12992#447-63" class="citation internal">seizures and forfeitures</a></li>
 </ul>
-
-
 {% endblock %}
 
 {% block reg_sidebar %}

--- a/atf_eregs/templates/regulations/landing_447.html
+++ b/atf_eregs/templates/regulations/landing_447.html
@@ -2,32 +2,45 @@
 
 {% block reg_title %}
 <h2 class="banner-text">Importation of Arms, Ammunition and Implements of War</h2>
-<p>Part 447 regulations relate to that portion of section 38 of the Arms
-Export Control Act of 1976, as amended, which is concerned with the
-importation of arms, ammunition and implements of war.</p>
+<p>This regulation explains restrictions on importing munitions into the U.S., as a matter that affects world peace and the security and foreign policy of the U.S.</p>
 {% endblock %}
 
 {% block reg_main_content %}
-<div class="important group">We are still in the process of verifying the content of this regulation.</div>
-<h3 class="list-header">The Regulation covers topics such as:</h3>
+<h3 class="list-header">Important topics include:</h3>
 <ul class="tag-list">
-  <li>Definitions</li>
-  <li>United States Munitions Import List</li>
-  <li>Registration and permit requirements</li>
-  <li>Restrictions and exemptions</li>
-  <li>Penalties, seizures and forfeitures</li>
+  <li><a href="/447-21/2015-12992#447-21" class="citation internal">The United States Munitions Import List</a> (items that are subject to controls)</li>
+  <li><a href="/447-31/2015-12992#447-31" class="citation internal">Registration</a> and <a href="/447-41/2015-12992#447-41" class="citation internal">permit</a> requirements for importing them</li>
+  <li><a href="/447-52/2015-12992#447-52" class="citation internal">Import restrictions that apply to specific countries</a></li>
+  <li><a href="/447-53/2015-12992#447-53-a" class="citation internal">Exemptions to import requirements</a></li>
+  <li>Penalties for <a href="/447-61/2015-12992#447-61" class="citation internal">unlawful importation</a> and <a href="/447-62/2015-12992#447-62" class="citation internal">false statements or concealment of facts</a>; <a href="/447-63/2015-12992#447-63" class="citation internal">seizures and forfeitures</a></li>
 </ul>
+
+
 {% endblock %}
 
 {% block reg_sidebar %}
 <div class="content-wrap">
-  <h3>Additional Resources</h3>
+  <h3>Related law</h3>
   <ul>
-    <li><a href="https://www.gpo.gov/fdsys/pkg/USCODE-2011-title22/pdf/USCODE-2011-title22-chap39-subchapIII-sec2778.pdf"
-           class="external" target="_blank">Arms Export Control Act (USC
-           22)</a></li>
+    <li><a href="https://www.gpo.gov/fdsys/pkg/USCODE-2011-title22/pdf/USCODE-2011-title22-chap39-subchapIII-sec2778.pdf" class="external" target="_blank">Section 38 of the Arms Export Control Act (U.S.C. 22)</a></li>
+  </ul>
+  
+  <h3>Ask questions</h3>
+  <ul>
+    <li><a href="https://www.atf.gov/contact/licensing-and-other-services" class="external" target="_blank">Call the Firearms &amp; Explosives Imports Branch</a></li>
+<li><a href="https://www.atf.gov/contact" class="external" target="_blank">Submit a Firearms and Explosives Import Question or Concern</a></li>
+  </ul>
+  
+    <h3>Additional resources</h3>
+  <ul>
     <li><a href="https://www.atf.gov/qa-category/imports-exports"
            class="external" target="_blank">Imports &amp; Exports Q&amp;A</a></li>
+    <li><a href="https://www.atf.gov/firearms/import-firearms-ammunition-and-implements-war" class="external" target="_blank">Permit application form</a></li>
+    
+    <h3>Related tools</h3>
+  <ul>
+    <li><a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=70394195a3edf623eba7ce77a1bddff1&amp;node=27:3.0.1.2.2&amp;rgn=div5" class="external" target="_blank">View this regulation on e-CFR (Electronic Code of Federal Regulations)</a></li>
+    <li><a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D=19&amp;conditions%5Bterm%5D=Importation+of+Arms%2C+Ammunition+and+Implements+of+War&amp;order=newest&amp;quiet=true" class="external" target="_blank">Related rules, proposed rules, and notices in the Federal Register</a></li><li><a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=Importation%252Bof%252BArms%252C%252BAmmunition%252Band%252BImplements%252Bof%252BWar;dct=FR%252BPR%252BN%252BO;cat=LES" class="external" target="_blank">Related open and closed comment periods on Regulations.gov</a></li>
   </ul>
 </div>
 {% endblock %}

--- a/atf_eregs/templates/regulations/landing_447.html
+++ b/atf_eregs/templates/regulations/landing_447.html
@@ -28,19 +28,20 @@
   <h3>Ask questions</h3>
   <ul>
     <li><a href="https://www.atf.gov/contact/licensing-and-other-services" class="external" target="_blank">Call the Firearms &amp; Explosives Imports Branch</a></li>
-<li><a href="https://www.atf.gov/contact" class="external" target="_blank">Submit a Firearms and Explosives Import Question or Concern</a></li>
+    <li><a href="https://www.atf.gov/contact" class="external" target="_blank">Submit a Firearms and Explosives Import Question or Concern</a></li>
   </ul>
   
-    <h3>Additional resources</h3>
+  <h3>Additional resources</h3>
   <ul>
-    <li><a href="https://www.atf.gov/qa-category/imports-exports"
-           class="external" target="_blank">Imports &amp; Exports Q&amp;A</a></li>
+    <li><a href="https://www.atf.gov/qa-category/imports-exports" class="external" target="_blank">Imports &amp; Exports Q&amp;A</a></li>
     <li><a href="https://www.atf.gov/firearms/import-firearms-ammunition-and-implements-war" class="external" target="_blank">Permit application form</a></li>
-    
-    <h3>Related tools</h3>
+  </ul>
+
+  <h3>Related tools</h3>
   <ul>
     <li><a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=70394195a3edf623eba7ce77a1bddff1&amp;node=27:3.0.1.2.2&amp;rgn=div5" class="external" target="_blank">View this regulation on e-CFR (Electronic Code of Federal Regulations)</a></li>
-    <li><a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D=19&amp;conditions%5Bterm%5D=Importation+of+Arms%2C+Ammunition+and+Implements+of+War&amp;order=newest&amp;quiet=true" class="external" target="_blank">Related rules, proposed rules, and notices in the Federal Register</a></li><li><a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=Importation%252Bof%252BArms%252C%252BAmmunition%252Band%252BImplements%252Bof%252BWar;dct=FR%252BPR%252BN%252BO;cat=LES" class="external" target="_blank">Related open and closed comment periods on Regulations.gov</a></li>
+    <li><a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D=19&amp;conditions%5Bterm%5D=Importation+of+Arms%2C+Ammunition+and+Implements+of+War&amp;order=newest&amp;quiet=true" class="external" target="_blank">Related rules, proposed rules, and notices in the Federal Register</a></li>
+    <li><a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=Importation%252Bof%252BArms%252C%252BAmmunition%252Band%252BImplements%252Bof%252BWar;dct=FR%252BPR%252BN%252BO;cat=LES" class="external" target="_blank">Related open and closed comment periods on Regulations.gov</a></li>
   </ul>
 </div>
 {% endblock %}


### PR DESCRIPTION
Here's a work in progress to demonstrate a few ideas - this takes the [current page for part 447](https://atf-eregs.18f.gov/447) and makes some changes to make it easier to understand for readers (#227):

* The intro sentence briefly summarizes the impact of the regulation, speaking directly to the reader with ordinary language.
* The list of topics notes the most important sections of the regulation and links directly to those items.
* The legal disclaimer links to the resources it mentions, so that readers can easily figure out how to get an official legal version if they need one.
* The sidebar includes links to relevant contact information, permit application forms, and related tools (e-CFR, a Federal Register search for the title of the regulation, and a Regulations.gov search for the title of the regulation).