### PR TITLE
Update "Trust, but verify" to "Legal limitations of this tool"

### DIFF
--- a/atf_eregs/templates/regulations/generic_landing.html
+++ b/atf_eregs/templates/regulations/generic_landing.html
@@ -6,11 +6,11 @@ like to provide a consistent disclaimer. Overextends tells django to use the
 {% endcomment %}
 
 {% block legal_disclaimer %}
-<h4 tabindex="0" class="important">Trust, but verify</h4>
+<h4 tabindex="0" class="important">Legal limitations of this tool</h4>
 
-<p><strong>Legal limitations of this tool:</strong> The ATF’s eRegulations tool
-is an editorial compilation of material and not an official legal edition of
-the <a href="https://www.archives.gov/federal-register/cfr/" class="external"
+<p>The ATF’s eRegulations tool is an editorial compilation of material and not
+an official legal edition of the <a
+href="https://www.archives.gov/federal-register/cfr/" class="external"
 target="_blank">Code of Federal Regulations</a> or the <a
 href="https://www.federalregister.gov/" class="external"
 target="_blank">Federal Register</a>. We have made every effort to ensure the


### PR DESCRIPTION
This is a simple change to address feedback from ATF (https://github.com/18F/atf-eregs/issues/262) that a more straightforward title for the legal disclaimer would help readers.