### PR TITLE
Use different elastic search config

### DIFF
--- a/atf_eregs/settings/prod.py
+++ b/atf_eregs/settings/prod.py
@@ -27,10 +27,14 @@ vcap_app = json.loads(os.environ.get('VCAP_APPLICATION', '{}'))
 ALLOWED_HOSTS = ['localhost'] + vcap_app.get('application_uris', [])
 
 vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-es_config = vcap_services.get('elasticsearch-swarm', [])
-if es_config:
+es_services = []
+for service_name, services in vcap_services.items():
+    if 'elasticsearch' in service_name:
+        es_services.extend(services)
+
+if es_services:
     HAYSTACK_CONNECTIONS['default'] = {
         'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-        'URL': es_config[0]['credentials']['uri'],
+        'URL': es_services[0]['credentials']['uri'],
         'INDEX_NAME': 'eregs',
     }


### PR DESCRIPTION
We were using an outdated elastic search connector from cloud.gov. In
switching to the recommended version, we discovered the key in the VCAP config
is slightly different. Account for both by using a substring match