### PR TITLE
Issue 63 user provided service

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ regardless of what you have locally and regardless of what you've built the
 front-end against. Be sure to always update your local libraries (via `pip`)
 before building and pushing.
 
+### Services
+
+This application uses the `rds` and `elasticsearch-swarm` services on cloud.gov. Services are bound to applications in th emanifest files. To create services:
+
+```
+cf create-service rds micro-psql atf-db
+cf create-service elasticsearch-swarm-1.7.1 1x atf-eregs-search-1.7.1
+```
+
 ### Credentials
 
 Our cloud.gov stack should have a user-provided service named `atf-eregs-creds` including the following credentials:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ before it will be visible to users. However, we don't want to allow the
 general public to modify the regulatory data, so we need to authenticate.
 Currently, this is implemented via HTTP Basic Auth and a very long user name
 and password (effectively creating an API key). See the `HTTP_AUTH_USER` and
-`HTTP_AUTH_PASSWORD` environment variables in cloud.gov for more.
+`HTTP_AUTH_PASSWORD` credentials in cloud.gov for more.
 
 Currently, sending data looks something like this (from `regulations-parser`)
 
@@ -117,11 +117,7 @@ $ eregs pipeline 27 646 https://{HTTP_AUTH_USER}:{HTTP_AUTH_PASSWORD}@{LIVE_OR_D
 ```
 
 This updates the data, but does not update the search index and will not clear
-various caches. It's generally best to `cf restage` the application at this
-point, which clears the caches and rebuilds the search index. Note that this
-will also pull down the latest versions of the libraries (see the next
-section); as a result it's generally best to do a full deploy after updating
-data.
+various caches. It's generally best to `cf restage` the application at this point, which clears the caches and rebuilds the search index. Note that this will also pull down the latest versions of the libraries (see the next section); as a result it's generally best to do a full deploy after updating data.
 
 ## Deploying Code
 
@@ -145,11 +141,19 @@ regardless of what you have locally and regardless of what you've built the
 front-end against. Be sure to always update your local libraries (via `pip`)
 before building and pushing.
 
-### Environment
+### Credentials
 
-Our cloud.gov stack should have the following env vars set
+Our cloud.gov stack should have a user-provided service named `atf-eregs-creds` including the following credentials:
 
 * `HTTP_AUTH_USER` - at least 32 characters long
 * `HTTP_AUTH_PASSWORD` - at least 32 characters long
 * `NEW_RELIC_LICENSE_KEY`
 * `NEW_RELIC_APP_NAME`
+
+To create this service:
+
+```
+$ cf cups atf-eregs-creds -p '{"HTTP_AUTH_USER": "...", "HTTP_AUTH_PASSWORD": "...", "NEW_RELIC_LICENSE_KEY": "...", "NEW_RELIC_APP_NAME": "..."}'
+```
+
+To update, substitute `cf uups` for `cf cups`.

--- a/README.md
+++ b/README.md
@@ -125,12 +125,14 @@ If the code within `atf-eregs`, `regulations-core`, or `regulations-site` has
 been updated, you will want to deploy the updated code to cloud.gov. At the
 moment, we build all of the front-end code locally, shipping the compiled
 CSS/JS when deploying. This means we'll need to update our libraries, build
-the new front end, and push the result.
+the new front end, and push the result. Always specify a manifest file using
+the `-f` option when deploying to cloud.gov.
 
 ```bash
 $ pip install -r requirements.txt   # updates the -core/-site repositories
 $ python manage.py compile_frontend   # builds the frontend
-$ cf push
+$ cf target -o eregs -s dev
+$ cf push -f manifest_dev.yml
 ```
 
 Confusingly, although the front-end compilation step occurs locally, all other
@@ -143,7 +145,7 @@ before building and pushing.
 
 ### Services
 
-This application uses the `rds` and `elasticsearch-swarm` services on cloud.gov. Services are bound to applications in th emanifest files. To create services:
+This application uses the `rds` and `elasticsearch-swarm` services on cloud.gov. Services are bound to applications in the manifest files. To create services:
 
 ```
 cf create-service rds micro-psql atf-db

--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -1,11 +1,10 @@
-import json
 import os
 
-from regcore.settings.base import *
+from regcore.settings.base import *  # noqa
 REGCORE_APPS = tuple(INSTALLED_APPS)
 REGCORE_DATABASES = dict(DATABASES)
 
-from regulations.settings.base import *
+from regulations.settings.base import *  # noqa
 REGSITE_APPS = tuple(INSTALLED_APPS)
 
 INSTALLED_APPS = ('overextends', 'atf_eregs',) + REGCORE_APPS + REGSITE_APPS

--- a/atf_eregs/settings/prod.py
+++ b/atf_eregs/settings/prod.py
@@ -1,16 +1,16 @@
-import json
-import os
+import re
 
 import dj_database_url
+from cfenv import AppEnv
 
-from .base import *
+from .base import *  # noqa
 
 DEBUG = False
 TEMPLATE_DEBUG = False
 ANALYTICS = {
     'GOOGLE': {
-       'GTM_SITE_ID': '',
-       'GA_SITE_ID': 'UA-48605964-38',
+        'GTM_SITE_ID': '',
+        'GA_SITE_ID': 'UA-48605964-38',
     },
     'DAP': {
         'AGENCY': 'DOJ',
@@ -22,19 +22,17 @@ DATABASES = {
     'default': dj_database_url.config()
 }
 
+env = AppEnv()
 
-vcap_app = json.loads(os.environ.get('VCAP_APPLICATION', '{}'))
-ALLOWED_HOSTS = ['localhost'] + vcap_app.get('application_uris', [])
+HTTP_AUTH_USER = env.get_credential('HTTP_AUTH_USER')
+HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')
 
-vcap_services = json.loads(os.environ.get('VCAP_SERVICES', '{}'))
-es_services = []
-for service_name, services in vcap_services.items():
-    if 'elasticsearch' in service_name:
-        es_services.extend(services)
+ALLOWED_HOSTS = ['localhost'] + env.uris
 
-if es_services:
+elastic_service = env.get_service(name=re.compile('elasticsearch'))
+if elastic_service:
     HAYSTACK_CONNECTIONS['default'] = {
         'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',
-        'URL': es_services[0]['credentials']['uri'],
+        'URL': elastic_service.credentials['uri'],
         'INDEX_NAME': 'eregs',
     }

--- a/atf_eregs/wsgi.py
+++ b/atf_eregs/wsgi.py
@@ -1,8 +1,18 @@
 import os
+
+import newrelic.agent
+from cfenv import AppEnv
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "atf_eregs.settings")
 # important that the whitenoise import is after the line above
 from whitenoise.django import DjangoWhiteNoise
+
+env = AppEnv()
+
+settings = newrelic.agent.global_settings()
+settings.app_name = env.get_credential('NEW_RELIC_APP_NAME')
+settings.license_key = env.get_credential('NEW_RELIC_LICENSE_KEY')
+newrelic.agent.initialize()
 
 application = DjangoWhiteNoise(get_wsgi_application())

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,9 @@
 ---
-command: python manage.py refresh && python manage.py collectstatic --noinput && newrelic-admin run-program waitress-serve --port=$VCAP_APP_PORT atf_eregs.wsgi:application
+command: python manage.py refresh && python manage.py collectstatic --noinput && run-program waitress-serve --port=$VCAP_APP_PORT atf_eregs.wsgi:application
 
+services:
+  # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, NEW_RELIC_LICENSE_KEY, and NEW_RELIC_APP_NAME
+  - atf-eregs-creds
 env:
   DJANGO_SETTINGS_MODULE: atf_eregs.settings.prod
   NEW_RELIC_CONFIG_FILE: newrelic.ini

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -1,9 +1,10 @@
 ---
-command: python manage.py refresh && python manage.py collectstatic --noinput && run-program waitress-serve --port=$VCAP_APP_PORT atf_eregs.wsgi:application
+command: python manage.py refresh && python manage.py collectstatic --noinput && waitress-serve --port=$VCAP_APP_PORT atf_eregs.wsgi:application
 
 services:
   # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, NEW_RELIC_LICENSE_KEY, and NEW_RELIC_APP_NAME
   - atf-eregs-creds
+  - atf-db
 env:
   DJANGO_SETTINGS_MODULE: atf_eregs.settings.prod
   NEW_RELIC_CONFIG_FILE: newrelic.ini

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -4,7 +4,6 @@ command: python manage.py refresh && python manage.py collectstatic --noinput &&
 services:
   # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, NEW_RELIC_LICENSE_KEY, and NEW_RELIC_APP_NAME
   - atf-eregs-creds
-  - atf-db
 env:
   DJANGO_SETTINGS_MODULE: atf_eregs.settings.prod
   NEW_RELIC_CONFIG_FILE: newrelic.ini

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,0 +1,7 @@
+---
+inherit: manifest_base.yml
+host: atf-eregs-demo
+services:
+  - atf-eregs-search-dev-1.7.1
+applications:
+  - name: atf-site

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -3,5 +3,6 @@ inherit: manifest_base.yml
 host: atf-eregs-demo
 services:
   - atf-eregs-search-dev-1.7.1
+  - atf-db
 applications:
   - name: atf-site

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -3,5 +3,6 @@ inherit: manifest_base.yml
 host: atf-eregs
 services:
   - atf-eregs-search-prod-1.7.1
+  - atf-eregs-db
 applications:
   - name: atf-eregs

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,0 +1,7 @@
+---
+inherit: manifest_base.yml
+host: atf-eregs
+services:
+  - atf-eregs-search-prod-1.7.1
+applications:
+  - name: atf-eregs

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ requests==2.9.1
 -e git+https://github.com/18F/regulations-site.git#egg=regulations
 
 # atf-specific/cloud.gov
-cfenv==0.4.0
+cfenv==0.5.1
 dj-database-url==0.3.0
 django-overextends==0.4.1
 newrelic==2.60.0.46


### PR DESCRIPTION
Get credentials from user-provided service.

* Document user-provided service
* Set basic auth credentials from service
* Initialize new relic manually from service
* Clean up a few flake8 warnings

Notes:
* It's kind of ugly, but setting the basic auth credentials in `settings.py` seems to work. The issue is that regulations-core tries to pull the creds from the environment, but this patch proposes to get them from a user-provided service instead.
* I don't have permission to deploy this, so it wouldn't be entirely surprising if it doesn't quite work. If this looks roughly correct and I can get permission, I'll verify that it actually works.

@cmc333333 