### PR TITLE
ATF-specific regulations-parser extensions.

### DIFF
--- a/eregs_extensions/extend_regparser/extensions.py
+++ b/eregs_extensions/extend_regparser/extensions.py
@@ -1,0 +1,3 @@
+additional_preprocessors = [
+    "extend_regparser.preprocs.USCode"
+]

--- a/eregs_extensions/extend_regparser/extensions.py
+++ b/eregs_extensions/extend_regparser/extensions.py
@@ -1,3 +1,0 @@
-additional_preprocessors = [
-    "extend_regparser.preprocs.USCode"
-]

--- a/eregs_extensions/extend_regparser/preprocs/__init__.py
+++ b/eregs_extensions/extend_regparser/preprocs/__init__.py
@@ -1,0 +1,26 @@
+# vim: set encoding=utf-8
+"""Set of transforms we run on notice XML to account for common inaccuracies
+in the XML"""
+from lxml import etree
+from regparser.tree.xml_parser.preprocessors import PreProcessorBase
+
+
+class USCode(PreProcessorBase):
+    """478.103 contains a chunk of the US Code, but does not delineate it
+    clearly from the rest of the text of the containing poster. We've created
+    `USCODE` tags to clear up this confusion, but we need to modify the XML to
+    insert them in the appropriate spot"""
+    MARKER = ("//SECTNO[contains(., '478.103')]/.."     # In 478.103
+              "//HD[contains(., '18 U.S.C.')]")  # US Code header
+
+    def transform(self, xml):
+        for hd in xml.xpath(self.MARKER):
+            uscode = etree.Element("USCODE")
+            next_el = hd.getnext()
+            while next_el is not None and next_el.tag != 'HD':
+                uscode.append(next_el)
+                next_el = hd.getnext()
+
+            hd_parent = hd.getparent()
+            hd_idx = hd_parent.index(hd)
+            hd_parent.insert(hd_idx + 1, uscode)

--- a/eregs_extensions/setup.py
+++ b/eregs_extensions/setup.py
@@ -4,7 +4,6 @@ ns = "eregs_ns.parser"  # The namespace for regulations-parser extensions.
 fs = "extend_regparser"  # The directory name for the package.
 entry_points = {
     "%s.preprocessors" % ns: [
-        "preprocessor_list = %s.extensions:additional_preprocessors" % fs,
         "USCode = %s.preprocs:USCode" % fs
     ]
 }

--- a/eregs_extensions/setup.py
+++ b/eregs_extensions/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup
+
+ns = "eregs_ns.parser"  # The namespace for regulations-parser extensions.
+fs = "extend_regparser"  # The directory name for the package.
+entry_points = {
+    "%s.preprocessors" % ns: [
+        "preprocessor_list = %s.extensions:additional_preprocessors" % fs,
+        "USCode = %s.preprocs:USCode" % fs
+    ]
+}
+
+setup(
+    name=fs,
+    version="1.0.0",
+    packages=[fs],
+    classifiers=[
+        'License :: Public Domain',
+        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication'
+    ],
+    entry_points=entry_points
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ pyelasticsearch==1.4
 psycopg2==2.6.1
 waitress==0.8.10
 whitenoise==2.0.6
+
+# extensions
+-e eregs_extensions


### PR DESCRIPTION
This creates a home for extensions specific to the ATF, such as a regulations-processor preprocessor for US Code extracts. See https://github.com/18F/regulations-parser/pull/177 for how it integrates with regulations-parser.