### PR TITLE
Include instances and domains in manifests.

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -1,6 +1,8 @@
 ---
 command: python manage.py refresh && python manage.py collectstatic --noinput && waitress-serve --port=$VCAP_APP_PORT atf_eregs.wsgi:application
-
+domains:
+  - apps.cloud.gov
+  - 18f.gov
 services:
   # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD, NEW_RELIC_LICENSE_KEY, and NEW_RELIC_APP_NAME
   - atf-eregs-creds

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,6 +1,7 @@
 ---
 inherit: manifest_base.yml
 host: atf-eregs
+instances: 5
 services:
   - atf-eregs-search-prod-1.7.1
   - atf-eregs-db


### PR DESCRIPTION
[Resolves #360]

@cmc333333 I'm guessing we only want to scale up to multiple instances for production, but if that's not right, I'll move the `instances` key to `manifest_base.yml`.