### PR TITLE
Remove ol-tag.html inclusion

### DIFF
--- a/atf_eregs/templates/atf_eregs/poster_wrapper.html
+++ b/atf_eregs/templates/atf_eregs/poster_wrapper.html
@@ -23,9 +23,7 @@
     Prevent the EXTRACT from adding another depth level to the markup
     {% endcomment %}
     {% with node=node.children|first %}
-      {% with first_child=node.children|first %}
-        {% include "regulations/ol-tag.html" %}
-      {% endwith %}
+      <ol class="level-{{node.list_level|add:1}}">
       {% for c in node.children %}
         {% with node=c %}
           {% include node.template_name %}


### PR DESCRIPTION
This subtemplate provided some logic on which type of li markers to use. We no
longer use the browser provided li markers, however, so this isn't needed any
longer.