### PR TITLE
More precise links to Regulations.gov and FR for landing pages

### DIFF
--- a/atf_eregs/templates/regulations/landing_447.html
+++ b/atf_eregs/templates/regulations/landing_447.html
@@ -40,7 +40,7 @@
   <h3>Related tools</h3>
   <ul>
     <li>View this regulation on <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=70394195a3edf623eba7ce77a1bddff1&amp;node=27:3.0.1.2.2&amp;rgn=div5" class="external" aria-label="Link opens in a new window" target="_blank">e-CFR (Electronic Code of Federal Regulations)</a></li>
-    <li>Related rules, proposed rules, and notices in the <a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D=19&amp;conditions%5Bterm%5D=Importation+of+Arms%2C+Ammunition+and+Implements+of+War&amp;order=newest&amp;quiet=true" class="external" aria-label="Link opens in a new window" target="_blank">Federal Register</a></li>
+    <li>Related rules, proposed rules, and notices in the <a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D%5B%5D=19&amp;conditions%5Bterm%5D=%22Importation+of+Arms%2C+Ammunition+and+Implements+of+War%22&amp;order=newest&amp;quiet=true" class="external" aria-label="Link opens in a new window" target="_blank">Federal Register</a></li>
     <li>Related open and closed comment periods on <a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=Importation%252Bof%252BArms%252C%252BAmmunition%252Band%252BImplements%252Bof%252BWar;dct=FR%252BPR%252BN%252BO;cat=LES" class="external" aria-label="Link opens in a new window" target="_blank">Regulations.gov</a></li>
   </ul>
 </div>

--- a/atf_eregs/templates/regulations/landing_478.html
+++ b/atf_eregs/templates/regulations/landing_478.html
@@ -82,8 +82,8 @@
   <h3>Related tools</h3>
   <ul>
     <li>View this regulation on <a href="http://www.ecfr.gov/cgi-bin/retrieveECFR?gp=&amp;SID=2717433fd3d41e66975f2fa2a49cf2de&amp;mc=true&amp;r=PART&amp;n=pt27.3.478" class="external" aria-label="Link opens in a new window" target="_blank">e-CFR (Electronic Code of Federal Regulations)</a></li>
-    <li>Related rules, proposed rules, and notices in the <a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D%5B%5D=19&amp;conditions%5Bterm%5D=Commerce+in+Firearms+and+Ammunition&amp;order=newest&amp;quiet=true" class="external" aria-label="Link opens in a new window" target="_blank">Federal Register</a></li>
-    <li>Related open and closed comment periods on <a href="http://www.regulations.gov/#!searchResults;rpp=25;po=0;s=Commerce%252Bin%252BFirearms%252Band%252BAmmunition;fp=true;ns=true" class="external" aria-label="Link opens in a new window" target="_blank">Regulations.gov</a></li>
+    <li>Related rules, proposed rules, and notices in the <a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D%5B%5D=19&amp;conditions%5Bterm%5D=%22Commerce+in+Firearms+and+Ammunition%22&amp;order=newest&amp;quiet=true" class="external" aria-label="Link opens in a new window" target="_blank">Federal Register</a></li>
+    <li>Related open and closed comment periods on <a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=%2522Commerce%252Bin%252BFirearms%252Band%252BAmmunition%2522;fp=true;dct=FR%252BPR%252BN%252BO;a=ATF" class="external" aria-label="Link opens in a new window" target="_blank">Regulations.gov</a></li>
   </ul>
 </div>
 

--- a/atf_eregs/templates/regulations/landing_479.html
+++ b/atf_eregs/templates/regulations/landing_479.html
@@ -72,8 +72,8 @@
   <h3>Related tools</h3>
   <ul>
     <li>View this regulation on <a href="http://www.ecfr.gov/cgi-bin/text-idx?SID=3348fa35fa821aaaff8cd8d898a5dedd&amp;mc=true&amp;node=pt27.3.479&amp;rgn=div5" class="external" aria-label="Link opens in a new window" target="_blank">e-CFR (Electronic Code of Federal Regulations)</a></li>
-    <li>Related rules, proposed rules, and notices in the <a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D%5B%5D=19&amp;conditions%5Bterm%5D=Machine+Guns%2C+Destructive+Devices%2C+and+Certain+Other+Firearms&amp;order=newest&amp;quiet=true" class="external" aria-label="Link opens in a new window" target="_blank">Federal Register</a></li>
-    <li>Related open and closed comment periods on <a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=Machine%252BGuns%252C%252BDestructive%252BDevices%252C%252Band%252BCertain%252BOther%252BFirearms;fp=true;dct=FR%252BPR%252BN%252BO;a=ATF" class="external" aria-label="Link opens in a new window" target="_blank">Regulations.gov</a></li>
+    <li>Related rules, proposed rules, and notices in the <a href="https://www.federalregister.gov/articles/search?conditions%5Bagency_ids%5D%5B%5D=19&amp;conditions%5Bterm%5D=%22Machine+Guns%2C+Destructive+Devices%2C+and+Certain+Other+Firearms%22&amp;order=newest&amp;quiet=true" class="external" aria-label="Link opens in a new window" target="_blank">Federal Register</a></li>
+    <li>Related open and closed comment periods on <a href="http://www.regulations.gov/#!searchResults;rpp=25;so=DESC;sb=commentDueDate;po=0;s=%2522Machine%252BGuns%252C%252BDestructive%252BDevices%252C%252Band%252BCertain%252BOther%252BFirearms%2522;fp=true;dct=FR%252BPR%252BN%252BO;a=ATF" class="external" aria-label="Link opens in a new window" target="_blank">Regulations.gov</a></li>
   </ul>
   
 </div>


### PR DESCRIPTION
Small changes to improve the right sidebar links to relevant search results on regulations.gov and federalregister.gov for 447, 478, and 479.