### PR TITLE
Update to latest py-cfenv.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ requests==2.9.1
 -e git+https://github.com/18F/regulations-site.git#egg=regulations
 
 # atf-specific/cloud.gov
-cfenv==0.5.1
+cfenv==0.5.2
 dj-database-url==0.4.0
 django-overextends==0.4.1
 gunicorn==19.4.5


### PR DESCRIPTION
Prior to 0.5.2, py-cfenv returned instance index as a string, but the
`refresh` management command (correctly) expects an integer. This patch
updates to the latest version of py-cfenv, which fixes this behavior.

This is why migrations didn't run on push--thanks @cmc333333 for catching.

#thatfeelingwhen you forget the interface on your own library
#lulz