### PR TITLE
Prefer test_utils versions of libraries

### DIFF
--- a/eregs_extensions/atf_regparser/tests/layers_tests.py
+++ b/eregs_extensions/atf_regparser/tests/layers_tests.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from mock import patch
 
 from atf_regparser import layers
-from tests.http_mixin import HttpMixin
+from regparser.test_utils.http_mixin import HttpMixin
 
 
 class RulingsTests(HttpMixin, TestCase):

--- a/eregs_extensions/atf_regparser/tests/preprocessor_tests.py
+++ b/eregs_extensions/atf_regparser/tests/preprocessor_tests.py
@@ -1,21 +1,21 @@
 # vim: set encoding=utf-8
 from unittest import TestCase
 
-from tests.xml_builder import XMLBuilderMixin
 from atf_regparser.preprocs import USCode
+from regparser.test_utils.xml_builder import XMLBuilder
 
 
-class USCodeTests(XMLBuilderMixin, TestCase):
+class USCodeTests(TestCase):
     def test_uscode_transform(self):
         """US Code issues"""
-        with self.tree.builder("PART") as part:
-            with part.REGTEXT(ID="RT1") as regtext:
-                with regtext.SECTION() as section:
-                    section.SECTNO(u"§ 478.103")
-                    section.HD("18 U.S.C. 922(x)", SOURCE="HD3")
-                    section.P("Some Content")
-                    section.HD("Whatever", SOURCE="HED")
-        xml = self.tree.render_xml()
+        with XMLBuilder("PART") as ctx:
+            with ctx.REGTEXT(ID="RT1"):
+                with ctx.SECTION():
+                    ctx.SECTNO(u"§ 478.103")
+                    ctx.HD("18 U.S.C. 922(x)", SOURCE="HD3")
+                    ctx.P("Some Content")
+                    ctx.HD("Whatever", SOURCE="HED")
+        xml = ctx.xml
 
         USCode().transform(xml)
 

--- a/eregs_extensions/extensions-outline.rst
+++ b/eregs_extensions/extensions-outline.rst
@@ -60,10 +60,8 @@ And would likely need ``etree``::
 They would also need tests. The tests would need the following import lines::
 
     from unittest import TestCase
-    from tests.xml_builder import XMLBuilderMixin
+    from regparser.test_utils.xml_builder import XMLBuilder
     from mib_regparser.preprocs import <whatever the test is for>
-
-The ``tests.xml_builder`` namespacing is problematic and will probably be changed to ``regparser.tests.xml_builder`` soon.
 
 Note that the test has to reflect the filesystem name ``mib_regparser``—in other words, each test has to change if that name changes.
 


### PR DESCRIPTION
Per eregs/regulations-parser#214, use the `regparser` namespaced test
libraries