### PR TITLE
Add Python3 support

### DIFF
--- a/eregs_extensions/atf_regparser/layers.py
+++ b/eregs_extensions/atf_regparser/layers.py
@@ -62,7 +62,7 @@ class Rulings(Layer):
         config = self.load_config()
         meta = self.doc_metadata()
         matched = [(ruling, label_id)
-                   for ruling, labels in config.iteritems()
+                   for ruling, labels in config.items()
                    for label_id in labels
                    if ruling in meta]
         self.label_to_rulings = defaultdict(dict)    # nested dictionaries

--- a/eregs_extensions/atf_regparser/tests/layers_tests.py
+++ b/eregs_extensions/atf_regparser/tests/layers_tests.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from mock import patch
+import six
 
 from atf_regparser import layers
 from regparser.test_utils.http_mixin import HttpMixin
@@ -47,8 +48,8 @@ class RulingsTests(HttpMixin, TestCase):
 
         rulings = layers.Rulings(None)
         rulings.pre_process()
-        self.assertEqual(['123-47', '123-48-h'],
-                         rulings.label_to_rulings.keys())
+        six.assertCountEqual(self, ['123-47', '123-48-h'],
+                             rulings.label_to_rulings.keys())
         for label_id in ('123-47', '123-48-h'):
             self.assertEqual(rulings.label_to_rulings[label_id], {
                 '1111-22': {'url': 'http://example.com/1111-22',


### PR DESCRIPTION
This is holding up the Python3 version of regulations-parser