### PR TITLE
Fix reg landing images

### DIFF
--- a/atf_eregs/static/regulations/css/less/module/custom/landing.less
+++ b/atf_eregs/static/regulations/css/less/module/custom/landing.less
@@ -9,7 +9,6 @@
     height: 225px;
     /* To span the full width, we'll use absolute positioning */
     position: absolute;
-    z-index: -100;
     left: 0;
     right: 0;
 


### PR DESCRIPTION
Don't need the z-index anymore as the div comes before the text that is placed
on top of it. This regression arose due to setting a white background instead
of none (transparent).

Resolves eregs/notice-and-comment#404