### PR TITLE
Fix ATF Rulings

### DIFF
--- a/atf_eregs/sidebar.py
+++ b/atf_eregs/sidebar.py
@@ -9,7 +9,7 @@ class Rulings(SidebarBase):
         """Fetch the rulings layer data from the API, find any relating to
         this section (including its sub paragraphs); pass them to the
         template"""
-        data = http_client.layer('atf-rulings', self.label_id, self.version)
+        data = http_client.layer('atf-rulings', 'cfr', self.label_id, self.version)
         data = data or {}
         rulings = {}
         for key, value in data.items():


### PR DESCRIPTION
We modified the signature of a method called in ATF-eRegs. Tests did not catch
it as the relevant library is mocked out.

Resolves #434