### PR TITLE
Pin -site version

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -1,6 +1,8 @@
 import os
 
 from regcore.settings.base import *  # noqa
+from regcore.settings.base import (  # explicitly referenced below
+    INSTALLED_APPS, DATABASES)
 REGCORE_APPS = tuple(INSTALLED_APPS)
 REGCORE_DATABASES = dict(DATABASES)
 

--- a/atf_eregs/settings/dev.py
+++ b/atf_eregs/settings/dev.py
@@ -1,4 +1,5 @@
 from .base import *     # noqa
+from .base import CACHES    # explicitly referenced below
 
 DEBUG = True
 

--- a/atf_eregs/settings/prod.py
+++ b/atf_eregs/settings/prod.py
@@ -4,6 +4,7 @@ import dj_database_url
 from cfenv import AppEnv
 
 from .base import *  # noqa
+from .base import HAYSTACK_CONNECTIONS  # explicitly referenced below
 
 DEBUG = False
 TEMPLATE_DEBUG = False

--- a/atf_eregs/sidebar.py
+++ b/atf_eregs/sidebar.py
@@ -9,7 +9,8 @@ class Rulings(SidebarBase):
         """Fetch the rulings layer data from the API, find any relating to
         this section (including its sub paragraphs); pass them to the
         template"""
-        data = http_client.layer('atf-rulings', 'cfr', self.label_id, self.version)
+        data = http_client.layer('atf-rulings', 'cfr', self.label_id,
+                                 self.version)
         data = data or {}
         rulings = {}
         for key, value in data.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jsonschema==2.5.1
 # regulations-site
 # django already covered
 requests==2.9.1
--e git+https://github.com/18F/regulations-site.git#egg=regulations
+-e git+https://github.com/18F/regulations-site.git@5.1.0#egg=regulations
 
 # atf-specific/cloud.gov
 cfenv==0.5.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,5 @@
 django-nose
-flake8
+pyflakes==1.2.3
+pycodestyle==2.0.0
+flake8==2.6.2
 lxml


### PR DESCRIPTION
As we make a big shift to SASS come version 6.0.0, we will need to update
downstream dependencies (ATF, FEC, EPA, etc.) one at a time. By pinning ATF to
this working version, we can avoid incompatibilities. It may be worth pinning
-core as well, but I'll kick that can down the road until it's necessary.

Resolves 18F/eregs-platform#20