### PR TITLE
Minor CSS tweak

### DIFF
--- a/atf_eregs/static/regulations/css/scss/module/custom/_about.scss
+++ b/atf_eregs/static/regulations/css/scss/module/custom/_about.scss
@@ -33,7 +33,7 @@
     color: #d14124;
 }
 
-img.about-stopcompare-img {
+.about-stopcompare-img.about-stopcompare-img {
     margin-top: 35px;
 }
 


### PR DESCRIPTION
For regulation timeline explanation image #3 on about page, use multiple-specificity CSS class rather than element.class specificity.
Addresses https://github.com/18F/atf-eregs/pull/443#pullrequestreview-952457