### PR TITLE
Narrow change for defined term underlines to _only_ affect those colors.

### DIFF
--- a/atf_eregs/static/regulations/css/scss/_variables.scss
+++ b/atf_eregs/static/regulations/css/scss/_variables.scss
@@ -7,7 +7,7 @@ variables.scss contains all theme variable / variable overrides
 $orange_light: #FFF1D6;
 $blue_light: #00629F;
 $action_color: $blue_light;
-$gray_light: #767676;
+$definition_underline_color: #767676;
 
 /* Custom Vars */
 $atf_dark_text: #666666;

--- a/atf_eregs/static/regulations/css/scss/module/custom/_typography.scss
+++ b/atf_eregs/static/regulations/css/scss/module/custom/_typography.scss
@@ -48,3 +48,32 @@ h3 {
     text-transform: none;
 }
 
+/*  Definition Links
+  --------------
+  <a href="#" class="definition">defined term</a>
+*/
+
+.definition,
+.definition:link,
+.definition:visited {
+  color: $black;
+  text-decoration: none;
+  border-bottom: 1px solid $definition_underline_color;
+}
+
+.definition:hover,
+.definition:active {
+  border-bottom: 1px solid $definition_underline_color;
+  background-color: $gray_lighter;
+}
+
+.definition.active {
+  background-color: $gray_lighter;
+}
+
+.inline-interpretation {
+  .definition:link,
+  .definition:visited {
+     border-bottom: 1px solid $definition_underline_color;
+  }
+}


### PR DESCRIPTION
So it turns out that / 
`$gray_light` was used in a lot /
Of different places.