### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -22,7 +22,7 @@ DATABASES = {
 }
 
 API_BASE = 'http://localhost:{}/api/'.format(
-    os.environ.get('VCAP_APP_PORT', '8000'))
+    os.environ.get('PORT', '8000'))
 
 STATICFILES_DIRS = ['compiled']
 


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.