### PR TITLE
Change docs to point to the new app domain in govcloud

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -95,7 +95,7 @@ type: app
 #   text: Anchor text for the link
 #   category: Type of the link
 links:
-- url: https://atf-eregs.apps.cloud.gov/
+- url: https://atf-eregs.app.cloud.gov/
   text: ATF eRegulations website
 
 # What tags does your organization's blog associate with your project? You can

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ATF eRegulations
 This repository contains code necessary to run a Bureau of Alcohol,
 Tobacco, Firearms and Explosives ([ATF](https://www.atf.gov)) instance of
-[eRegulations](https://eregs.github.io) (a regulation parser, API, and viewer). Live version: [https://atf-eregs.apps.cloud.gov/](https://atf-eregs.apps.cloud.gov/)
+[eRegulations](https://eregs.github.io) (a regulation parser, API, and viewer). Live version: [https://atf-eregs.app.cloud.gov/](https://atf-eregs.app.cloud.gov/)
 
 This code glues together general-purpose/non-agency-specific eRegulations libraries (which are not in this repository) with ATF-specific styles, templates, and plugins (which are in this repository).
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,11 +9,11 @@ if [ $# -ne 1 ]; then
   exit
 fi
 
+NAME="atf-eregs"
+
 if [ $SPACE = 'prod' ]; then
-  NAME="atf-eregs"
   MANIFEST="manifest_prod.yml"
 elif [ $SPACE = 'dev' ]; then
-  NAME="atf-site"
   MANIFEST="manifest_dev.yml"
 else
   echo "Unknown space: $SPACE"

--- a/docs/local_setup.rst
+++ b/docs/local_setup.rst
@@ -68,7 +68,7 @@ In this scenario, we just need to configure the UI to point to the live API:
 
 .. code-block:: bash
 
-  echo "API_BASE = 'https://atf-eregs.apps.cloud.gov/api/'" >> local_settings.py
+  echo "API_BASE = 'https://atf-eregs.app.cloud.gov/api/'" >> local_settings.py
 
 Parsing Regulations
 -------------------


### PR DESCRIPTION
Tenant apps use `app.cloud.gov` on Govcloud as the default domain