### PR TITLE
Update remaining Python libs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "eregs_libs/regulations-site"]
 	path = eregs_libs/regulations-site
 	url = https://github.com/eregs/regulations-site.git
-	branch = 7.1.0
+	branch = 8.0.0
 [submodule "eregs_libs/regulations-core"]
 	path = eregs_libs/regulations-core
 	url = https://github.com/eregs/regulations-core.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,4 @@ simplejson==3.10.0        # via pyelasticsearch
 six==1.10.0               # via furl, orderedmultidict, pyelasticsearch, python-dateutil, regcore, regulations
 urllib3==1.22             # via elasticsearch, pyelasticsearch, requests
 vine==1.1.3               # via amqp
-whitenoise==3.2.2
+whitenoise==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ gunicorn==19.7.1
 jmespath==0.9.1           # via boto3, botocore
 jsonschema==2.6.0         # via regcore
 kombu==4.0.2              # via celery
-newrelic==2.72.1.53
+newrelic==2.88.1.73
 orderedmultidict==0.7.11  # via furl
 psycopg2==2.7.1
 pyelasticsearch==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ furl==1.0.0               # via cfenv
 futures==3.1.1            # via regulations
 gunicorn==19.7.1
 jmespath==0.9.1           # via boto3, botocore
-jsonschema==2.5.1         # via regcore
+jsonschema==2.6.0         # via regcore
 kombu==4.0.2              # via celery
 newrelic==2.72.1.53
 orderedmultidict==0.7.11  # via furl

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,9 @@ boto3==1.4.4              # via regulations
 botocore==1.5.17          # via boto3, s3transfer
 cached-property==1.3.0    # via regulations
 celery==4.0.2             # via regulations
-certifi==2017.1.23        # via pyelasticsearch
+certifi==2017.4.17        # via pyelasticsearch, requests
 cfenv==0.5.3
+chardet==3.0.4            # via requests
 dj-database-url==0.4.2
 django-haystack==2.6.1
 django-mptt==0.8.7        # via regcore
@@ -23,6 +24,7 @@ enum34==1.1.6             # via regulations
 furl==1.0.0               # via cfenv
 futures==3.1.1            # via regulations
 gunicorn==19.7.1
+idna==2.5                 # via requests
 jmespath==0.9.1           # via boto3, botocore
 jsonschema==2.6.0         # via regcore
 kombu==4.0.2              # via celery
@@ -35,10 +37,10 @@ pytz==2017.2              # via celery, django
 regcore==3.1.0
 regulations==7.1.0
 requests-toolbelt==0.7.1  # via regulations
-requests==2.11.1          # via regulations, requests-toolbelt
+requests==2.18.2          # via regulations, requests-toolbelt
 s3transfer==0.1.10        # via boto3
 simplejson==3.10.0        # via pyelasticsearch
 six==1.10.0               # via furl, orderedmultidict, pyelasticsearch, python-dateutil, regcore, regulations
-urllib3==1.20             # via elasticsearch, pyelasticsearch
+urllib3==1.22             # via elasticsearch, pyelasticsearch, requests
 vine==1.1.3               # via amqp
 whitenoise==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django==1.11.3            # via django-haystack, django-overextends, regcore, re
 docutils==0.13.1          # via botocore
 elasticsearch==1.9.0      # via pyelasticsearch
 enum34==1.1.6             # via regulations
-furl==0.5.7               # via cfenv
+furl==1.0.0               # via cfenv
 futures==3.0.5            # via regulations
 gunicorn==19.6.0
 jmespath==0.9.1           # via boto3, botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ botocore==1.5.17          # via boto3, s3transfer
 cached-property==1.3.0    # via regulations
 celery==4.0.2             # via regulations
 certifi==2017.1.23        # via pyelasticsearch
-cfenv==0.5.2
+cfenv==0.5.3
 dj-database-url==0.4.1
 django-haystack==2.6.1
 django-mptt==0.8.7        # via regcore

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cached-property==1.3.0    # via regulations
 celery==4.0.2             # via regulations
 certifi==2017.1.23        # via pyelasticsearch
 cfenv==0.5.3
-dj-database-url==0.4.1
+dj-database-url==0.4.2
 django-haystack==2.6.1
 django-mptt==0.8.7        # via regcore
 django-overextends==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ orderedmultidict==0.7.11  # via furl
 psycopg2==2.7.3
 pyelasticsearch==1.4
 python-dateutil==2.6.0    # via botocore
-pytz==2016.10             # via celery, django
+pytz==2017.2              # via celery, django
 regcore==3.1.0
 regulations==7.1.0
 requests-toolbelt==0.7.1  # via regulations

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.13.1          # via botocore
 elasticsearch==1.9.0      # via pyelasticsearch
 enum34==1.1.6             # via regulations
 furl==1.0.0               # via cfenv
-futures==3.0.5            # via regulations
+futures==3.1.1            # via regulations
 gunicorn==19.6.0
 jmespath==0.9.1           # via boto3, botocore
 jsonschema==2.5.1         # via regcore

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ elasticsearch==1.9.0      # via pyelasticsearch
 enum34==1.1.6             # via regulations
 furl==1.0.0               # via cfenv
 futures==3.1.1            # via regulations
-gunicorn==19.6.0
+gunicorn==19.7.1
 jmespath==0.9.1           # via boto3, botocore
 jsonschema==2.5.1         # via regcore
 kombu==4.0.2              # via celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-amqp==2.1.4               # via kombu
-billiard==3.5.0.2         # via celery
-boto3==1.4.4              # via regulations
-botocore==1.5.17          # via boto3, s3transfer
 cached-property==1.3.0    # via regulations
-celery==4.0.2             # via regulations
 certifi==2017.4.17        # via pyelasticsearch, requests
 cfenv==0.5.3
 chardet==3.0.4            # via requests
@@ -18,29 +13,22 @@ django-haystack==2.6.1
 django-mptt==0.8.7        # via regcore
 django-overextends==0.4.3
 django==1.11.3            # via django-haystack, django-overextends, regcore, regulations
-docutils==0.13.1          # via botocore
 elasticsearch==1.9.0      # via pyelasticsearch
 enum34==1.1.6             # via regulations
 furl==1.0.0               # via cfenv
 futures==3.1.1            # via regulations
 gunicorn==19.7.1
 idna==2.5                 # via requests
-jmespath==0.9.1           # via boto3, botocore
 jsonschema==2.6.0         # via regcore
-kombu==4.0.2              # via celery
 newrelic==2.88.1.73
 orderedmultidict==0.7.11  # via furl
 psycopg2==2.7.3
 pyelasticsearch==1.4
-python-dateutil==2.6.0    # via botocore
-pytz==2017.2              # via celery, django
+pytz==2017.2              # via django
 regcore==3.1.0
-regulations==7.1.0
-requests-toolbelt==0.7.1  # via regulations
-requests==2.18.2          # via regulations, requests-toolbelt
-s3transfer==0.1.10        # via boto3
+regulations==8.0.0
+requests==2.18.2          # via regulations
 simplejson==3.10.0        # via pyelasticsearch
-six==1.10.0               # via furl, orderedmultidict, pyelasticsearch, python-dateutil, regcore, regulations
+six==1.10.0               # via furl, orderedmultidict, pyelasticsearch, regcore, regulations
 urllib3==1.22             # via elasticsearch, pyelasticsearch, requests
-vine==1.1.3               # via amqp
 whitenoise==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ jsonschema==2.6.0         # via regcore
 kombu==4.0.2              # via celery
 newrelic==2.88.1.73
 orderedmultidict==0.7.11  # via furl
-psycopg2==2.7.1
+psycopg2==2.7.3
 pyelasticsearch==1.4
 python-dateutil==2.6.0    # via botocore
 pytz==2016.10             # via celery, django

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -27,8 +27,8 @@ enum34==1.1.6
 flake8==3.3.0
 furl==1.0.0
 futures==3.1.1
-gitdb2==2.0.0             # via gitpython
-gitpython==2.1.3          # via bandit
+gitdb2==2.0.2             # via gitpython
+gitpython==2.1.5          # via bandit
 gunicorn==19.7.1
 httpretty==0.8.14
 idna==2.5
@@ -39,9 +39,9 @@ mccabe==0.6.1             # via flake8
 mock==2.0.0
 newrelic==2.88.1.73
 orderedmultidict==0.7.11
-pbr==3.0.0                # via mock, stevedore
+pbr==3.1.1                # via mock, stevedore
 psycopg2==2.7.3
-py==1.4.33                # via pytest
+py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyelasticsearch==1.4
 pyflakes==1.5.0           # via flake8
@@ -55,8 +55,8 @@ requests==2.18.2
 s3transfer==0.1.10
 simplejson==3.10.0
 six==1.10.0
-smmap2==2.0.1             # via gitdb2
-stevedore==1.21.0         # via bandit
+smmap2==2.0.3             # via gitdb2
+stevedore==1.25.0         # via bandit
 urllib3==1.22
 vine==1.1.3
 whitenoise==3.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -59,4 +59,4 @@ smmap2==2.0.1             # via gitdb2
 stevedore==1.21.0         # via bandit
 urllib3==1.22
 vine==1.1.3
-whitenoise==3.2.2
+whitenoise==3.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,13 +6,8 @@
 #
 -e file:///usr/src/app/eregs_libs/regulations-core
 -e file:///usr/src/app/eregs_libs/regulations-site
-amqp==2.1.4
 bandit==1.4.0
-billiard==3.5.0.2
-boto3==1.4.4
-botocore==1.5.17
 cached-property==1.3.0
-celery==4.0.2
 certifi==2017.4.17
 cfenv==0.5.3
 chardet==3.0.4
@@ -21,7 +16,6 @@ django-haystack==2.6.1
 django-mptt==0.8.7
 django-overextends==0.4.3
 django==1.11.3
-docutils==0.13.1
 elasticsearch==1.9.0
 enum34==1.1.6
 flake8==3.3.0
@@ -32,9 +26,7 @@ gitpython==2.1.5          # via bandit
 gunicorn==19.7.1
 httpretty==0.8.14
 idna==2.5
-jmespath==0.9.1
 jsonschema==2.6.0
-kombu==4.0.2
 mccabe==0.6.1             # via flake8
 mock==2.0.0
 newrelic==2.88.1.73
@@ -47,16 +39,12 @@ pyelasticsearch==1.4
 pyflakes==1.5.0           # via flake8
 pytest-django==3.1.2
 pytest==3.1.3
-python-dateutil==2.6.0
 pytz==2017.2
 pyyaml==3.12              # via bandit
-requests-toolbelt==0.7.1
 requests==2.18.2
-s3transfer==0.1.10
 simplejson==3.10.0
 six==1.10.0
 smmap2==2.0.3             # via gitdb2
 stevedore==1.25.0         # via bandit
 urllib3==1.22
-vine==1.1.3
 whitenoise==3.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,8 +13,9 @@ boto3==1.4.4
 botocore==1.5.17
 cached-property==1.3.0
 celery==4.0.2
-certifi==2017.1.23
+certifi==2017.4.17
 cfenv==0.5.3
+chardet==3.0.4
 dj-database-url==0.4.2
 django-haystack==2.6.1
 django-mptt==0.8.7
@@ -30,6 +31,7 @@ gitdb2==2.0.0             # via gitpython
 gitpython==2.1.3          # via bandit
 gunicorn==19.7.1
 httpretty==0.8.14
+idna==2.5
 jmespath==0.9.1
 jsonschema==2.6.0
 kombu==4.0.2
@@ -49,12 +51,12 @@ python-dateutil==2.6.0
 pytz==2017.2
 pyyaml==3.12              # via bandit
 requests-toolbelt==0.7.1
-requests==2.11.1
+requests==2.18.2
 s3transfer==0.1.10
 simplejson==3.10.0
 six==1.10.0
 smmap2==2.0.1             # via gitdb2
 stevedore==1.21.0         # via bandit
-urllib3==1.20
+urllib3==1.22
 vine==1.1.3
 whitenoise==3.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,7 +25,7 @@ elasticsearch==1.9.0
 enum34==1.1.6
 flake8==3.3.0
 furl==1.0.0
-futures==3.0.5
+futures==3.1.1
 gitdb2==2.0.0             # via gitpython
 gitpython==2.1.3          # via bandit
 gunicorn==19.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ cached-property==1.3.0
 celery==4.0.2
 certifi==2017.1.23
 cfenv==0.5.3
-dj-database-url==0.4.1
+dj-database-url==0.4.2
 django-haystack==2.6.1
 django-mptt==0.8.7
 django-overextends==0.4.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -46,7 +46,7 @@ pycodestyle==2.3.1        # via flake8
 pyelasticsearch==1.4
 pyflakes==1.5.0           # via flake8
 pytest-django==3.1.2
-pytest==3.0.7
+pytest==3.1.3
 python-dateutil==2.6.0
 pytz==2017.2
 pyyaml==3.12              # via bandit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -38,7 +38,7 @@ mock==2.0.0
 newrelic==2.88.1.73
 orderedmultidict==0.7.11
 pbr==3.0.0                # via mock, stevedore
-psycopg2==2.7.1
+psycopg2==2.7.3
 py==1.4.33                # via pytest
 pycodestyle==2.3.1        # via flake8
 pyelasticsearch==1.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -35,7 +35,7 @@ jsonschema==2.6.0
 kombu==4.0.2
 mccabe==0.6.1             # via flake8
 mock==2.0.0
-newrelic==2.72.1.53
+newrelic==2.88.1.73
 orderedmultidict==0.7.11
 pbr==3.0.0                # via mock, stevedore
 psycopg2==2.7.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -28,7 +28,7 @@ furl==1.0.0
 futures==3.1.1
 gitdb2==2.0.0             # via gitpython
 gitpython==2.1.3          # via bandit
-gunicorn==19.6.0
+gunicorn==19.7.1
 httpretty==0.8.14
 jmespath==0.9.1
 jsonschema==2.5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -46,7 +46,7 @@ pyflakes==1.5.0           # via flake8
 pytest-django==3.1.2
 pytest==3.0.7
 python-dateutil==2.6.0
-pytz==2016.10
+pytz==2017.2
 pyyaml==3.12              # via bandit
 requests-toolbelt==0.7.1
 requests==2.11.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -31,7 +31,7 @@ gitpython==2.1.3          # via bandit
 gunicorn==19.7.1
 httpretty==0.8.14
 jmespath==0.9.1
-jsonschema==2.5.1
+jsonschema==2.6.0
 kombu==4.0.2
 mccabe==0.6.1             # via flake8
 mock==2.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -24,7 +24,7 @@ docutils==0.13.1
 elasticsearch==1.9.0
 enum34==1.1.6
 flake8==3.3.0
-furl==0.5.7
+furl==1.0.0
 futures==3.0.5
 gitdb2==2.0.0             # via gitpython
 gitpython==2.1.3          # via bandit

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ botocore==1.5.17
 cached-property==1.3.0
 celery==4.0.2
 certifi==2017.1.23
-cfenv==0.5.2
+cfenv==0.5.3
 dj-database-url==0.4.1
 django-haystack==2.6.1
 django-mptt==0.8.7


### PR DESCRIPTION
This finishes up the Python side of #472 by upgrading the remaining Python libs. Most interesting is probably `requests`, which has many fewer dependencies now.