### PR TITLE
Clear copied frontend *before* collectstatic.

### DIFF
--- a/devops/compile_frontend.sh
+++ b/devops/compile_frontend.sh
@@ -10,6 +10,7 @@ fi
 # We don't want to use --clear as we don't want to delete node_modules
 rm -rf frontend_build/config frontend_build/regulations
 mkdir -p compiled
+rm -rf compiled/regulations
 docker-compose run --rm manage.py collectstatic --no-default-ignore --noinput > /dev/null
 # Copy config values
 cp frontend_build/config/.babelrc frontend_build/
@@ -17,5 +18,4 @@ cp frontend_build/config/Gruntfile.js frontend_build/
 cp frontend_build/config/package.json frontend_build/
 # Build
 docker-compose run --rm grunt $1
-rm -rf compiled/regulations
 cp -r frontend_build/regulations compiled/regulations


### PR DESCRIPTION
Django will look first in the `compiled` directory (then in the
regulations-site dirs) when searching for a static file. This is the correct
behavior when running the application, but not when we're building the
frontend (i.e. when we're filing that `compiled` directory). We should clear
out `compiled` earlier in the build script to accommodate this need.