### PR TITLE
Add script to build "atf-resources" layer

### DIFF
--- a/atf_eregs/atf_resources.py
+++ b/atf_eregs/atf_resources.py
@@ -1,0 +1,107 @@
+"""ATF has associated "ruling" documents, which we'd like to tag to particular
+paragraphs. To do that we need to
+1) read a config yaml file which maps rulings to regulation paragraphs
+2) read a listing of rulings from atf.gov's API
+3) connect the two."""
+from collections import defaultdict
+from typing import Dict, List, NamedTuple, NewType
+import logging
+import os.path
+import re
+
+from regcore.db import storage
+from regcore.layer import LayerParams
+from regcore_write.views.layer import child_layers
+import requests
+import yaml
+
+
+JSON_URL = 'https://www.atf.gov/rules-and-regulations/json'
+SPLIT_RE = re.compile(r'(?P<id>[0-9-]+) - (?P<title>.*)')
+logger = logging.getLogger(__name__)
+LAYER_NAME = 'atf-resources'
+
+
+ResourceId = NewType('ResourceId', str)
+LabelId = NewType('LabelId', str)
+
+
+class ResourceMeta(NamedTuple):
+    url: str
+    id: ResourceId
+    title: str
+
+
+ResourceLayer = Dict[LabelId, Dict[ResourceId, Dict[str, str]]]
+ResourceConfig = Dict[ResourceId, List[LabelId]]
+ResourceMapping = Dict[ResourceId, ResourceMeta]
+
+
+def load_config() -> ResourceConfig:
+    """The config file lives in the code repository; we must find it and parse
+    it"""
+    this_file = os.path.abspath(__file__)
+    root_dir = os.path.dirname(os.path.dirname(this_file))
+    data_path = os.path.join(
+        root_dir, 'eregs_extensions', 'atf_regparser', 'rulings.yml')
+    with open(data_path, 'r') as f:
+        data = yaml.safe_load(f)
+        # convert types
+        return {ResourceId(resource): [LabelId(label) for label in labels]
+                for resource, labels in data.items()}
+
+
+def doc_metadata() -> ResourceMapping:
+    """Convert results from www.atf.gov into a dict, associating ruling ids
+    with meta data about that ruling"""
+    listing = requests.get(JSON_URL).json()
+    listing = [n.get('node', {}) for n in listing.get('nodes', [])]
+    listing = [n for n in listing if n.get('Document Type') == 'Ruling']
+    docs = {}
+    for meta in listing:
+        match = SPLIT_RE.match(meta.get('Title', ''))
+        if not match:
+            logging.warning('Could not parse ruling title: %s',
+                            meta.get('Title', ''))
+        else:
+            ident = ResourceId(match.group('id'))
+            docs[ident] = ResourceMeta(
+                meta.get('URL', ''), ident, match.group('title'))
+    if not docs:
+        logging.warning('No results from www.atf.gov. Format changed?')
+    return docs
+
+
+def create_layer(config: ResourceConfig, meta: ResourceMapping,
+                 cfr_part: LabelId) -> ResourceLayer:
+    """Combine configuration with data we retrieved from atf.gov to create a
+    layer object suitable for passing over to the regcore machinery."""
+    matched = [(ResourceId(ruling), LabelId(label_id))
+               for ruling, labels in config.items()
+               for label_id in labels
+               if ruling in meta and label_id.startswith(cfr_part)]
+    layer = defaultdict(dict)
+    for ruling, label_id in matched:
+        layer[label_id][ruling] = meta[ruling]._asdict()
+    return layer
+
+
+def fetch_and_save_resources() -> None:
+    versions_by_part = defaultdict(list)
+    for version, cfr_part in storage.for_documents.listing('cfr'):
+        versions_by_part[cfr_part].append(version)
+
+    config = load_config()
+    meta = doc_metadata()
+
+    for cfr_part, versions in versions_by_part.items():
+        layer = create_layer(config, meta, LabelId(cfr_part))
+        for version in versions:
+            params = LayerParams(
+                'cfr', '{0}/{1}'.format(version, cfr_part), cfr_part)
+            storage.for_layers.bulk_delete(
+                LAYER_NAME, params.doc_type, params.doc_id)
+            storage.for_layers.bulk_insert(
+                child_layers(params, layer), LAYER_NAME, params.doc_type)
+            logger.info('Loaded Additional Resources layer for %s@%s',
+                        cfr_part, version)

--- a/atf_eregs/management/commands/fetch_atf_resources.py
+++ b/atf_eregs/management/commands/fetch_atf_resources.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from atf_eregs.atf_resources import fetch_and_save_resources
+
+
+class Command(BaseCommand):
+    help = 'Load "Additional Resources" data from atf.gov'
+
+    def handle(self, *args, **options):
+        fetch_and_save_resources()

--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -72,6 +72,30 @@ else:
     API_BASE = 'http://localhost:{}/api/'.format(
         os.environ.get('PORT', '8000'))
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'default': {
+            'format': '%(levelname)s %(asctime)s %(name)-20s %(message)s',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+        }
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        },
+    }
+}
+
+
 if DEBUG:
     CACHES['default']['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
     CACHES['eregs_longterm_cache']['BACKEND'] = \

--- a/atf_eregs/tests/atf_resources_tests.py
+++ b/atf_eregs/tests/atf_resources_tests.py
@@ -1,0 +1,91 @@
+import json
+import re
+from unittest.mock import call, Mock
+
+import httpretty
+import pytest
+from regcore.layer import LayerParams
+
+from atf_eregs import atf_resources
+
+
+def test_load_config():
+    """We shouldn't get an explosion when loading the ruling config."""
+    results = atf_resources.load_config()
+    assert results
+
+
+@httpretty.activate
+def test_doc_metadata():
+    data = {'nodes': [
+        {'node': {'Title': '1111-22 - A Title Here',
+                  'Document Type': 'Ruling',
+                  'URL': 'http://example.com/1111-22'}},
+        {'node': {'Title': 'Bad Title',
+                  'Document Type': 'Ruling',
+                  'URL': 'http://example.com/bad'}},
+        {'node': {'Title': '1111-33 - Not a Ruling',
+                  'Document Type': 'Open Letter',
+                  'URL': 'http://example.com/open'}},
+        {'node': {'Title': '1111-44 - Last Ruling',
+                  'Document Type': 'Ruling',
+                  'URL': 'http://example.com/1111-44'}},
+    ]}
+    httpretty.register_uri(httpretty.GET, re.compile('.*'), json.dumps(data),
+                           content_type='application/json')
+    assert atf_resources.doc_metadata() == {
+        '1111-22': atf_resources.ResourceMeta(
+            'http://example.com/1111-22', '1111-22', 'A Title Here'),
+        '1111-44': atf_resources.ResourceMeta(
+            'http://example.com/1111-44', '1111-44', 'Last Ruling'),
+    }
+
+
+def test_create_layer():
+    config = {'2222-33': ['123-45', '123-46'],
+              '1111-22': ['123-47', '123-48-h']}
+    meta = {'1111-22': atf_resources.ResourceMeta(
+                'http://example.com/1111-22', '1111-22', 'A Title Here'),
+            '1111-44': atf_resources.ResourceMeta(
+                'http://example.com/1111-44', '1111-44', 'Last Ruling')}
+    results = atf_resources.create_layer(config, meta, '123')
+    assert {'123-47', '123-48-h'} == results.keys()
+    for data in results.values():
+        assert data == {'1111-22': {
+            'url': 'http://example.com/1111-22', 'id': '1111-22',
+            'title': 'A Title Here'
+        }}
+
+
+@pytest.mark.django_db
+def test_fetch_and_save_resources(monkeypatch):
+    """Verify that the correct calls are being made to the storage backend."""
+    monkeypatch.setattr(atf_resources, 'storage', Mock())
+    monkeypatch.setattr(atf_resources, 'load_config', Mock())
+    monkeypatch.setattr(atf_resources, 'doc_metadata', Mock())
+    monkeypatch.setattr(atf_resources, 'create_layer', Mock())
+    monkeypatch.setattr(atf_resources, 'child_layers', Mock())
+    storage = atf_resources.storage
+    storage.for_documents.listing.return_value = [
+        ('v1', 'cfrpart1'), ('v2', 'cfrpart1'), ('va', 'cfrpart2'),
+    ]
+
+    atf_resources.fetch_and_save_resources()
+
+    assert storage.for_documents.listing.call_args == call('cfr')
+    assert storage.for_layers.bulk_delete.call_args_list == [
+        call('atf-resources', 'cfr', 'v1/cfrpart1'),
+        call('atf-resources', 'cfr', 'v2/cfrpart1'),
+        call('atf-resources', 'cfr', 'va/cfrpart2'),
+    ]
+    assert atf_resources.child_layers.call_args_list == [
+        call(LayerParams('cfr', 'v1/cfrpart1', 'cfrpart1'),
+             atf_resources.create_layer.return_value),
+        call(LayerParams('cfr', 'v2/cfrpart1', 'cfrpart1'),
+             atf_resources.create_layer.return_value),
+        call(LayerParams('cfr', 'va/cfrpart2', 'cfrpart2'),
+             atf_resources.create_layer.return_value),
+    ]
+    assert storage.for_layers.bulk_insert.call_args_list == [
+        call(atf_resources.child_layers.return_value, 'atf-resources', 'cfr')
+    ]*3

--- a/eregs_extensions/devops/activate_then
+++ b/eregs_extensions/devops/activate_then
@@ -2,7 +2,7 @@
 PARSER_VERSION=4.3.1
 
 if [ ! -d .venv/bin ]; then
-  virtualenv .venv
+  python -m venv .venv
 fi
 source .venv/bin/activate
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ gunicorn
 newrelic
 psycopg2
 pyelasticsearch
+pyyaml
 regcore
 regulations
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ orderedmultidict==0.7.11  # via furl
 psycopg2==2.7.3
 pyelasticsearch==1.4
 pytz==2017.2              # via django
+pyyaml==3.12
 regcore==3.1.0
 regulations==8.0.0
 requests==2.18.2          # via regulations

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -40,7 +40,7 @@ pyflakes==1.5.0           # via flake8
 pytest-django==3.1.2
 pytest==3.1.3
 pytz==2017.2
-pyyaml==3.12              # via bandit
+pyyaml==3.12
 requests==2.18.2
 simplejson==3.10.0
 six==1.10.0


### PR DESCRIPTION
We have been generating ruling data in an extension to the parser. This clones most of that logic to generate a layer as a django management command so we can run it separately from the parser. @tadhg-ohiggins what do you think about the types here? I didn't run mypy, but was hoping they conveyed meaning a bit better.

Should resolve #489 