### PR TITLE
Always attach postgres.

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -65,7 +65,7 @@ SIDEBARS = (
 )
 
 
-USE_LIVE_DATA = 'DATABASE_URL' not in os.environ
+USE_LIVE_DATA = os.environ.get('USE_LIVE_DATA', 'FALSE').upper() == 'TRUE'
 if USE_LIVE_DATA:
     API_BASE = 'https://regulations.atf.gov/api/'
 else:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,14 @@ services:
       - database_data:/var/lib/postgresql/data
   prod: &PROD
     image: python:3.6.2
-    command: ./devops/activate_then ./devops/run_webserver.sh
+    command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_webserver.sh
     ports:
       - 9000:9000
     environment: &PROD_ENV
       PORT: 9000
       DJANGO_SETTINGS_MODULE: atf_eregs.settings.base
+      DATABASE_URL: postgres://postgres@persistent_db/postgres
+      USE_LIVE_DATA: "true"
       TMPDIR: /tmp
       STATIC_ROOT: frontend_build
       VCAP_APPLICATION: >
@@ -22,6 +24,8 @@ services:
     working_dir: /usr/src/app
     stdin_open: true
     tty: true
+    depends_on:
+      - persistent_db
   dev: &DEV
     <<: *PROD
     ports:
@@ -37,15 +41,12 @@ services:
     <<: *DEV
     ports:
       - 8001:8001
-    command: ./devops/wait_for_db_then ./devops/activate_then ./devops/run_webserver.sh
     environment:
       <<: *DEV_ENV
-      DATABASE_URL: postgres://postgres@persistent_db/postgres
       PORT: 8001
+      USE_LIVE_DATA: "false"
       VCAP_APPLICATION: >
         {"uris": ["localhost", "0.0.0.0", "127.0.0.1", "dev-with-db"]}
-    depends_on:
-      - persistent_db
 
 
   #---- Commands ----


### PR DESCRIPTION
Currently, we only attach postgres to the running ATF instance if we run
`dev-with-db` (otherwise, we're running with the live ATF data, skipping the
SQLite-based local API). As we test a postgres-based search, we need to have
Postgres running (even if it's not actively used).

This accomplishes that by using a specific env variable to signify that we
want to use the live data (rather than just testing for a database
connection).