### PR TITLE
Run rebuild_pgsql_index instead of haystack.

### DIFF
--- a/atf_eregs/management/commands/refresh.py
+++ b/atf_eregs/management/commands/refresh.py
@@ -10,6 +10,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         env = AppEnv()
         if env.index is None or env.index == 0:
-            management.call_command('migrate', fake_initial=True)
-            management.call_command('rebuild_index',
-                                    interactive=False, remove=True)
+            management.call_command('migrate')
+            management.call_command('rebuild_pgsql_index')


### PR DESCRIPTION
When we start our instances in cloud.gov, we run a custom "refresh" management
command. This had been rebuilding the search index, but that broke when
switching to the Postgres-backed search. This is currently preventing us from
deploying.