### PR TITLE
Related documents UI

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -63,6 +63,7 @@ DATA_LAYERS = (
 )
 
 SIDEBARS = (
+    'atf_eregs.sidebar.ATFResources',
     'atf_eregs.sidebar.Rulings',
     'regulations.generator.sidebar.help.Help',
 )

--- a/atf_eregs/sidebar.py
+++ b/atf_eregs/sidebar.py
@@ -9,7 +9,7 @@ class Rulings(SidebarBase):
         """Fetch the rulings layer data from the API, find any relating to
         this section (including its sub paragraphs); pass them to the
         template"""
-        data = http_client.layer('atf-resources', 'cfr', self.label_id,
+        data = http_client.layer('atf-rulings', 'cfr', self.label_id,
                                  self.version)
         data = data or {}
         rulings = {}

--- a/atf_eregs/sidebar.py
+++ b/atf_eregs/sidebar.py
@@ -21,3 +21,32 @@ class Rulings(SidebarBase):
         rulings = sorted(rulings.values(), key=lambda r: r['id'],
                          reverse=True)
         return {'rulings': rulings}
+
+
+class ATFResources(SidebarBase):
+    shorthand = 'atf-resources'
+
+    def context(self, http_client, request):
+        return {'count': 0, 'groups': []}
+        rulings = [
+            {'id': '2010-2', 'title': 'Some Example',
+             'url': 'http://example.com'},
+            {'id': '2010-1', 'title': 'Another Example',
+             'url': 'http://example.com'},
+        ]
+        forms = [
+            {'id': 'Form 123', 'title': 'Registering Stuff',
+             'url': 'http://example.com'},
+            {'id': 'Form 345', 'title': 'More Stuff',
+             'url': 'http://example.com'},
+        ]
+
+        # Example data
+        return {
+            'count': len(rulings) + len(forms),
+            'groups': [{
+                'name': 'Ruling', 'count': len(rulings), 'entries': rulings
+            }, {
+                'name': 'Form', 'count': len(forms), 'entries': forms
+            }],
+        }

--- a/atf_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/atf_eregs/static/regulations/css/scss/module/_custom.scss
@@ -6,5 +6,6 @@
 @import 'custom/about';
 @import 'custom/key-terms';
 @import 'custom/regulation-nav';
+@import 'custom/atf-resources';
 @import 'custom/mixins';
 @import 'custom/overrides';

--- a/atf_eregs/static/regulations/css/scss/module/custom/_atf-resources.scss
+++ b/atf_eregs/static/regulations/css/scss/module/custom/_atf-resources.scss
@@ -1,0 +1,80 @@
+#atf-resources {
+  $header_height: 40px;
+  $right_chevron: '\e002';
+  $down_chevron: '\e006';
+  $x_padding: 10px;   // as defined in ".regs-meta h4"
+
+  .group {
+    background-color: $gray_lightest;
+    border-bottom: 1px solid $gray_light;
+
+    &.has-content {
+      background-color: $blue_lightest;
+    }
+  }
+
+  .list-container {
+    padding: 0 $x_padding;
+    border-bottom: 1px solid $gray_light;
+  }
+
+  .list-container header {
+    background: none;           // reset
+    border-bottom: none;        // reset
+    height: $header_height;
+    line-height: $header_height;
+    border-top: 1px solid $gray_light;
+
+    &.first {
+      border-top: none;
+    }
+
+    a {
+      line-height: $header_height;
+    }
+
+    a:before {
+      content: $right_chevron;
+      color: $gray_dark;
+    }
+
+    &.open a:before {
+      content: $down_chevron;
+    }
+  }
+
+  h4, h5 {
+    height: $header_height;
+    font-size: 0.875em;
+    letter-spacing: 1px;
+    text-transform: none;   // reset
+    @include sans-font-regular;   // reset
+  }
+
+  h4 {
+    padding-left: $x_padding;       // this should be redundant
+    padding-right: $x_padding;      // this should be redundant
+  }
+
+  h5 {
+    display: inline;
+  }
+
+  li {
+    margin: 10px 0;
+  }
+
+  .entry-id {
+    display: block;
+  }
+
+  .chunk {
+    padding: 0 $x_padding;
+    border-bottom: none;  // reset
+  }
+
+  .explanation {
+    color: inherit;  // reset
+    margin: 0;
+  }
+}

--- a/atf_eregs/templates/regulations/sidebar/atf-resources.html
+++ b/atf_eregs/templates/regulations/sidebar/atf-resources.html
@@ -1,0 +1,42 @@
+{% load macros %}
+<section id="atf-resources" class="regs-meta">
+  {% if count %}
+    <header class="group has-content">
+      <h4><strong>{{ count }}</strong> Related document{{ count|pluralize }}</h4>
+    </header>
+    <div class="list-container">
+      {% for group in groups %}
+        <header class="expandable open{% if forloop.first %} first{% endif %}">
+          <h5 tabindex="0">
+            <strong>{{ group.count }}</strong> {{ group.name }}{{ group.count|pluralize }}
+          </h5>
+          <a href="#" tabindex="0">
+            <span class="icon-text">Show/Hide Contents</span>
+          </a>
+        </header>
+        <div class="chunk expand-drawer">
+          {% if group.name == "Ruling" %}
+            <p class="explanation">
+              These rulings help to interpret this section of the regulation.
+            </p>
+          {% endif %}
+          <ul>
+            {% for entry in group.entries %}
+              <li>
+                {% if entry.id %}
+                  <span class="entry-id">{{ entry.id }}</span>
+                {% endif %}
+                {% external_link url=entry.url text=entry.title %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <header class="group">
+      <h4>No related documents</h4>
+    </header>
+  {% endif %}
+</section>
+


### PR DESCRIPTION
This adds the templates and styles to display the "Related documents" sidebar widget. For the time being, it starts opened and is an _addition_ to the Rulings heading. Once this one is all good, we can delete the Rulings widget.

Looks like:
<img width="533" alt="screen shot 2017-08-11 at 6 12 41 pm" src="https://user-images.githubusercontent.com/326918/29233741-b2607342-7ec0-11e7-89ae-672e773a232f.png">
<img width="555" alt="screen shot 2017-08-11 at 6 12 19 pm" src="https://user-images.githubusercontent.com/326918/29233742-b2647488-7ec0-11e7-85e8-f6b9b0a131ef.png">

