### PR TITLE
Related documents backend replacement

### DIFF
--- a/atf_eregs/atf_resources.py
+++ b/atf_eregs/atf_resources.py
@@ -1,89 +1,94 @@
-"""ATF has associated "ruling" documents, which we'd like to tag to particular
-paragraphs. To do that we need to
-1) read a config yaml file which maps rulings to regulation paragraphs
-2) read a listing of rulings from atf.gov's API
-3) connect the two."""
 from collections import defaultdict
-from typing import Dict, List, NamedTuple, NewType
+from typing import List, NamedTuple, Optional
 import logging
 import os.path
-import re
 
 from regcore.db import storage
 from regcore.layer import LayerParams
 from regcore_write.views.layer import child_layers
-import requests
 import yaml
 
 
-JSON_URL = 'https://www.atf.gov/rules-and-regulations/json'
-SPLIT_RE = re.compile(r'(?P<id>[0-9-]+) - (?P<title>.*)')
 logger = logging.getLogger(__name__)
 LAYER_NAME = 'atf-resources'
 
 
-ResourceId = NewType('ResourceId', str)
-LabelId = NewType('LabelId', str)
+class Mapping(NamedTuple):
+    part: str
+    section: str
+    subsection: Optional[str] = None
+
+    def label(self):
+        """Convert to a hyphen-separated string"""
+        components = [self.part, self.section]
+        if self.subsection:
+            # convert paren syntax into ours
+            components.extend(
+                p.strip('()') for p in self.subsection.split(')('))
+        return '-'.join(components)
 
 
-class ResourceMeta(NamedTuple):
+class ResourceData(NamedTuple):
+    short_title: str
+    group: str
+    published: str  # this should encode a date, but we don't need to verify
+    mappings: List[Mapping]
     url: str
-    id: ResourceId
-    title: str
+    identifier: Optional[str] = None
 
 
-ResourceLayer = Dict[LabelId, Dict[ResourceId, Dict[str, str]]]
-ResourceConfig = Dict[ResourceId, List[LabelId]]
-ResourceMapping = Dict[ResourceId, ResourceMeta]
-
-
-def load_config() -> ResourceConfig:
-    """The config file lives in the code repository; we must find it and parse
-    it"""
+def fetch_resource_data(cfr_part: str) -> List[ResourceData]:
+    """Read data from ATF. Currently, this is stubbed by a local yaml file."""
     this_file = os.path.abspath(__file__)
-    root_dir = os.path.dirname(os.path.dirname(this_file))
-    data_path = os.path.join(
-        root_dir, 'eregs_extensions', 'atf_regparser', 'rulings.yml')
+    app_dir = os.path.dirname(this_file)
+    data_path = os.path.join(app_dir, 'related-docs.yml')
     with open(data_path, 'r') as f:
-        data = yaml.safe_load(f)
-        # convert types
-        return {ResourceId(resource): [LabelId(label) for label in labels]
-                for resource, labels in data.items()}
+        data = yaml.safe_load(f.read())
+        return [
+            ResourceData(
+                entry['short_title'],
+                entry['group'],
+                entry['published'],
+                [Mapping(str(m['part']), str(m['section']),
+                         m.get('subsection'))
+                 for m in entry['mappings']],
+                entry['url'],
+                entry.get('identifier'),
+            )
+            for entry in data
+        ]
 
 
-def doc_metadata() -> ResourceMapping:
-    """Convert results from www.atf.gov into a dict, associating ruling ids
-    with meta data about that ruling"""
-    listing = requests.get(JSON_URL).json()
-    listing = [n.get('node', {}) for n in listing.get('nodes', [])]
-    listing = [n for n in listing if n.get('Document Type') == 'Ruling']
-    docs = {}
-    for meta in listing:
-        match = SPLIT_RE.match(meta.get('Title', ''))
-        if not match:
-            logging.warning('Could not parse ruling title: %s',
-                            meta.get('Title', ''))
-        else:
-            ident = ResourceId(match.group('id'))
-            docs[ident] = ResourceMeta(
-                meta.get('URL', ''), ident, match.group('title'))
-    if not docs:
-        logging.warning('No results from www.atf.gov. Format changed?')
-    return docs
+class Entry(NamedTuple):
+    short_title: str
+    url: str
+    identifier: Optional[str] = None
 
 
-def create_layer(config: ResourceConfig, meta: ResourceMapping,
-                 cfr_part: LabelId) -> ResourceLayer:
-    """Combine configuration with data we retrieved from atf.gov to create a
-    layer object suitable for passing over to the regcore machinery."""
-    matched = [(ResourceId(ruling), LabelId(label_id))
-               for ruling, labels in config.items()
-               for label_id in labels
-               if ruling in meta and label_id.startswith(cfr_part)]
-    layer = defaultdict(dict)
-    for ruling, label_id in matched:
-        layer[label_id][ruling] = meta[ruling]._asdict()
+def create_layer(cfr_part: str, data: List[ResourceData]):
+    """Convert the ATF data into a layer, keyed by paragraph label_id."""
+    data = list(sorted(data, key=lambda d: (d.published, d.short_title),
+                       reverse=True))
+    layer = defaultdict(lambda: defaultdict(list))
+
+    for resource in data:
+        for mapping in resource.mappings:
+            if mapping.part == cfr_part:
+                entry = Entry(resource.short_title, resource.url,
+                              resource.identifier)
+                layer[mapping.label()][resource.group].append(entry._asdict())
+
     return layer
+
+
+def save_layer(cfr_part, layer, version):
+    """Write layer data to the database."""
+    params = LayerParams('cfr', '{0}/{1}'.format(version, cfr_part), cfr_part)
+    storage.for_layers.bulk_delete(LAYER_NAME, params.doc_type, params.doc_id)
+    storage.for_layers.bulk_insert(child_layers(params, layer), LAYER_NAME,
+                                   params.doc_type)
+    logger.info('Loaded Additional Resources layer for %s@%s', cfr_part,
+                version)
 
 
 def fetch_and_save_resources() -> None:
@@ -91,17 +96,8 @@ def fetch_and_save_resources() -> None:
     for version, cfr_part in storage.for_documents.listing('cfr'):
         versions_by_part[cfr_part].append(version)
 
-    config = load_config()
-    meta = doc_metadata()
-
     for cfr_part, versions in versions_by_part.items():
-        layer = create_layer(config, meta, LabelId(cfr_part))
+        data = fetch_resource_data(cfr_part)
+        layer = create_layer(cfr_part, data)
         for version in versions:
-            params = LayerParams(
-                'cfr', '{0}/{1}'.format(version, cfr_part), cfr_part)
-            storage.for_layers.bulk_delete(
-                LAYER_NAME, params.doc_type, params.doc_id)
-            storage.for_layers.bulk_insert(
-                child_layers(params, layer), LAYER_NAME, params.doc_type)
-            logger.info('Loaded Additional Resources layer for %s@%s',
-                        cfr_part, version)
+            save_layer(cfr_part, layer, version)

--- a/atf_eregs/related-docs.yml
+++ b/atf_eregs/related-docs.yml
@@ -1,0 +1,434 @@
+- identifier: 1976-25
+  short_title: Recordkeeping Requirements Salvaged Firearms
+  group: Ruling
+  published: 1976-01-25
+  mappings:
+    - part: 478
+      section: 122
+    - part: 478
+      section: 123
+    - part: 478
+      section: 125
+  url: https://www.atf.gov/firearms/docs/ruling/1976-25-recordkeeping-requirements-salvaged-firearms/download
+- identifier: 1976-22
+  short_title: Qualifying Tax Free Transfers
+  group: Ruling
+  published: 1976-01-22
+  mappings:
+    - part: 478
+      section: 44
+    - part: 479
+      section: 31
+    - part: 479
+      section: 32
+    - part: 479
+      section: 48
+    - part: 479
+      section: 88
+  url: https://www.atf.gov/firearms/docs/ruling/1976-22-qualifying-tax-free-transfers/download
+- identifier: 1976-15
+  short_title: Acquisition and Disposition of Pawned Firearms
+  group: Ruling
+  published: 1976-01-15
+  mappings:
+    - part: 478
+      section: 124
+      subsection: (a)
+    - part: 478
+      section: 125
+      subsection: (e)
+    - part: 478
+      section: 126a
+  url: https://www.atf.gov/firearms/docs/ruling/1976-15-acquisition-and-disposition-pawned-firearms/download
+- identifier: 1976-6
+  short_title: Tasers as Firearms
+  group: Ruling
+  published: 1976-01-06
+  mappings:
+    - part: 478
+      section: 11
+    - part: 479
+      section: 11
+  url: https://www.atf.gov/firearms/docs/ruling/1976-6-tasers-firearms/download
+- identifier: 1975-27
+  short_title: Sales or Delivers Between Licensees
+  group: Ruling
+  published: 1975-01-27
+  mappings:
+    - part: 478
+      section: 94
+  url: https://www.atf.gov/firearms/docs/ruling/1975-27-renewed-federal-firearms-license-conduct-business/download
+- identifier: 2012-5
+  short_title: Type 4 Magazine Construction
+  group: Ruling
+  published: 2012-01-05
+  mappings:
+    - part: 555
+      section: 29
+    - part: 555
+      section: 210
+  url: https://www.atf.gov/explosives/docs/ruling/2012-5-type-4-magazine-construction/download
+- identifier: 2012-2
+  short_title: Storage of Display Fireworks in Picking Bins
+  group: Ruling
+  published: 2012-01-02
+  mappings:
+    - part: 555
+      section: 214
+  url: https://www.atf.gov/explosives/docs/ruling/2012-2-storage-display-fireworks-picking-bins/download
+- identifier: 2011-3
+  short_title: Alternate Locks Authorized for Explosives Magazines
+  group: Ruling
+  published: 2011-01-03
+  mappings:
+    - part: 555
+      section: 207
+    - part: 555
+      section: 208
+    - part: 555
+      section: 209
+    - part: 555
+      section: 210
+    - part: 555
+      section: 211
+  url: https://www.atf.gov/explosives/docs/ruling/2011-3-alternate-locks-authorized-explosives-magazines/download
+- identifier: 2011-2
+  short_title: Locking Requirements for Outdoor Type 5 Bin and Silo Magazines
+  group: Ruling
+  published: 2011-01-02
+  mappings:
+    - part: 555
+      section: 211
+  url: https://www.atf.gov/explosives/docs/ruling/2011-2-locking-requirements-outdoor-type-5-bin-and-silo-magazines/download
+- identifier: 2010-7
+  short_title: Perforating Gun Storage
+  group: Ruling
+  published: 2010-01-07
+  mappings:
+    - part: 555
+      section: 205
+    - part: 555
+      section: 127
+    - part: 555
+      section: 218
+  url: https://www.atf.gov/explosives/docs/ruling/2010-7-perforating-gun-storage/download
+- identifier: Proc 2017-1
+  short_title: Facilitating Non-FFLTransfers of Firearms
+  group: Ruling
+  published: 2017-02-01
+  mappings:
+    - part: 478
+      section: 58
+    - part: 478
+      section: 102
+    - part: 478
+      section: 122
+    - part: 478
+      section: 123
+    - part: 478
+      section: 124
+    - part: 478
+      section: 125
+    - part: 478
+      section: 126a
+    - part: 478
+      section: 129
+  url: https://www.atf.gov/firearms/docs/ruling/atf-procedure-2017-1-facilitating-non-ffl-transfers-firearms/download
+
+
+
+
+
+- identifier: 5300.9
+  short_title: 4473- Part 1- Firearms Transfers Record- Over-the-Counter
+  group: Form
+  published: 2016-10-01
+  mappings:
+    - part: 478
+      section: 32
+    - part: 478
+      section: 96
+    - part: 478
+      section: 100
+    - part: 478
+      section: 102
+    - part: 478
+      section: 124
+    - part: 478
+      section: 125
+    - part: 478
+      section: 129
+    - part: 478
+      section: 131
+    - part: 478
+      section: 147
+  url: https://www.atf.gov/firearms/docs/4473-part-1-firearms-transaction-record-over-counter-atf-form-53009/download
+- identifier: 5300.38
+  short_title: Application for an Amended Federal Firearms License
+  group: Form
+  published: 2016-08-01
+  mappings:
+    - part: 478
+      section: 48
+    - part: 478
+      section: 52
+  url: https://www.atf.gov/firearms/docs/form/application-amended-federal-firearms-license-atf-form-530038/download
+- identifier: 3210.1
+  short_title: Application for Restoration of Firearms Privileges
+  group: Form
+  published: 2016-08-01
+  mappings:
+    - part: 478
+      section: 144
+  url: https://www.atf.gov/firearms/docs/form/application-restoration-firearms-privileges-atf-form-32101/download
+- identifier: 5320.20
+  short_title: Application to Transport Interstate or to Temporarily Export Certain National Firearms Act (NFA) Firearms
+  group: Form
+  published: 2016-08-01
+  mappings:
+    - part: 478
+      section: 28
+    - part: 478
+      section: 36
+  url: https://www.atf.gov/firearms/docs/form/application-transport-interstate-or-temporarily-export-certain-national-firearms/download
+- identifier: 5400.13
+  short_title: Application for Explosives License or Permit
+  group: Form
+  published: 2012-06-01
+  mappings:
+    - part: 555
+      section: 41
+    - part: 555
+      section: 42
+    - part: 555
+      section: 43
+    - part: 555
+      section: 44
+    - part: 555
+      section: 45
+  url: https://www.atf.gov/file/61596/download
+- identifier: 5400.29
+  short_title: Application for Restoration of Explosives Privileges
+  group: Form
+  published: 2015-11-01
+  mappings:
+    - part: 555
+      section: 142
+  url: https://www.atf.gov/explosives/docs/form/application-restoration-explosives-privileges-atf-form-540029/download
+- identifier: 5400.28
+  short_title: Employee Possessor Questionnaire
+  group: Form
+  published: 2013-02-01
+  mappings:
+    - part: 555
+      section: 45
+    - part: 555
+      section: 57
+  url: https://www.atf.gov/resource-center/docs/atf-f-5400-28pdf/download
+- identifier: 5400.4
+  short_title: Limited Permitee Transaction Report
+  group: Form
+  published: 2003-05-01
+  mappings:
+    - part: 555
+      section: 126
+  url: https://www.atf.gov/explosives/docs/form/limited-permitee-transaction-report-atf-form-54004/download
+- identifier: 5400.5
+  short_title: Report of Theft or Loss-Explosive Materials
+  group: Form
+  published: 2014-09-01
+  mappings:
+    - part: 555
+      section: 30
+  url: https://www.atf.gov/explosives/docs/form/report-theftloss-explosives-materials-atf-form-54005/download
+
+
+
+
+
+- short_title: Must a transferee provide his/her social security number on Form 4473?
+  group: FAQ
+  published: 2016-09-23
+  mappings:
+    - part: 478
+      section: 124
+      subsection: (c)(2)
+  url: https://www.atf.gov/firearms/qa/must-transferee-provide-his-or-her-social-security-number-atf-form-4473
+- short_title: Are the instructions attached to ATF Form 4473 required to be maintained with the Form 4473 as part of the licensee’s permanent firearms record?
+  group: FAQ
+  published: 2016-09-23
+  mappings:
+    - part: 478
+      section: 121
+    - part: 478
+      section: 129
+      subsection: (b)
+  url: https://www.atf.gov/firearms/qa/are-instructions-attached-atf-form-4473-required-be-maintained-form-4473-part-licensees
+- short_title: How long are licensee required to maintain ATF Forms 4473?
+  group: FAQ
+  published: 2016-09-23
+  mappings:
+    - part: 478
+      section: 129
+      subsection: (b)
+  url: https://www.atf.gov/firearms/qa/how-long-are-licensees-required-maintain-atf-forms-4473
+- short_title: May a licensee employ an individual who is prohibited from receiving or possessing firearms and ammunition?
+  group: FAQ
+  published: 2016-09-23
+  mappings:
+    - part: 478
+      section: 94
+  url: https://www.atf.gov/firearms/qa/may-licensee-employ-individual-who-prohibited-receiving-or-possessing-firearms-and
+- short_title: Does a licensee have to prepare a multiple sale report for the return of two or more pistols or revolvers to the same person from whom they were received?
+  group: FAQ
+  published: 2016-09-23
+  mappings:
+    - part: 478
+      section: 126a
+  url: https://www.atf.gov/firearms/qa/does-licensee-have-prepare-multiple-sale-report-return-two-or-more-pistols-or-revolvers
+- short_title: May a licensee lawfully transfer a frame or receiver to an unlicensed person who resides outside his or her state?
+  group: FAQ
+  published: 2016-09-23
+  mappings:
+    - part: 478
+      section: 99
+      subsection: (a)
+  url: https://www.atf.gov/firearms/qa/may-licensee-lawfully-transfer-frame-or-receiver-unlicensed-person-who-resides-outside
+- short_title: FFL Newsletter Sept 2016
+  group: FAQ
+  published: 2016-09-01
+  mappings:
+    - part: 478
+      section: 39a
+    - part: 478
+      section: 127
+    - part: 478
+      section: 113
+    - part: 478
+      section: 100
+    - part: 478
+      section: 125
+    - part: 478
+      section: 124
+    - part: 478
+      section: 112
+    - part: 479
+      section: 11
+    - part: 479
+      section: 90a
+    - part: 479
+      section: 141
+  url: https://www.atf.gov/firearms/docs/newsletter/ffl-newsletter-september-2016/download
+- short_title: FFL Newsletter 1992 Vol.2
+  group: FAQ
+  published: 1992-01-02
+  mappings:
+    - part: 478
+      section: 123
+    - part: 478
+      section: 52
+    - part: 478
+      section: 124
+    - part: 478
+      section: 171
+    - part: 478
+      section: 99
+    - part: 478
+      section: 148
+    - part: 478
+      section: 38
+    - part: 479
+      section: 111
+    - part: 479
+      section: 103
+    - part: 447
+      section: 52
+    - part: 447
+      section: 43
+  url: https://www.atf.gov/firearms/docs/newsletter/federal-firearms-licensees-newsletter-1992-volume-2/download
+
+
+
+
+
+- short_title: Alabama FFLs Brady
+  group: Open Letter
+  published: 2016-02-01
+  mappings:
+    - part: 478
+      section: 102
+      subsection: (d)
+    - part: 478
+      section: 131
+    - part: 478
+      section: 150
+  url: https://www.atf.gov/firearms/docs/open-letter/alabama-feb2016-open-letter-permanent-provisions-brady-lawpdf/download
+- short_title: Alaska FFLs ID Showing Residence
+  group: Open Letter
+  published: 2012-06-01
+  mappings:
+    - part: 478
+      section: 11
+    - part: 478
+      section: 124
+  url: https://www.atf.gov/firearms/docs/open-letter/alaska-jun2012-open-letter-identification-showing-residence-neither-street/download
+- short_title: Alaska FFLs Brady
+  group: Open Letter
+  published: 2005-10-01
+  mappings:
+    - part: 478
+      section: 102
+      subsection: (d)
+    - part: 478
+      section: 131
+  url: https://www.atf.gov/firearms/docs/open-letter/alaska-oct2005-open-letter-alaska-concealed-handgun-permits-marked-nics/download
+- short_title: End of Registration Period for Streetsweepers
+  group: Open Letter
+  published: 2001-04-01
+  mappings:
+    - part: 479
+      section: 111
+  url: https://www.atf.gov/firearms/docs/open-letter/all-ffls-apr2001-open-letter-end-registration-period-streetsweeper-striker/download
+- short_title: Child Safety Lock Act
+  group: Open Letter
+  published: 2006-04-01
+  mappings:
+    - part: 478
+      section: 73
+  url: https://www.atf.gov/firearms/docs/open-letter/all-ffls-apr2006-open-letter-child-safety-lock-act-2005/download
+- short_title: FFL Importers and Manufacturers – Marking Requirements Amended
+  group: Open Letter
+  published: 2001-04-01
+  mappings:
+    - part: 478
+      section: 92
+    - part: 479
+      section: 102
+  url: https://www.atf.gov/firearms/docs/open-letter/all-ffls-aug2001-open-letter-firearms-importer-and-manufacturer-marking/download
+- short_title: Extension of Time to Effect Importation of Approved Permits for Frames, Receivers, and Barrels
+  group: Open Letter
+  published: 2005-08-01
+  mappings:
+    - part: 478
+      section: 39
+    - part: 478
+      section: 111
+  url: https://www.atf.gov/firearms/docs/open-letter/all-ffls-aug2005-open-letter-extension-time-effect-importation-approved/download
+- short_title: Clarification for FFLs on Obtaining a Marking Variance
+  group: Open Letter
+  published: 2008-08-01
+  mappings:
+    - part: 478
+      section: 92
+    - part: 479
+      section: 102
+  url: https://www.atf.gov/firearms/docs/open-letter/all-ffls-aug2008-open-letter-clarification-ffls-obtaining-marking-variance/download
+- short_title: Guidelines for Natural Disasters
+  group: Open Letter
+  published: 2008-08-01
+  mappings:
+    - part: 478
+      section: 39a
+    - part: 478
+      section: 125
+  url: https://www.atf.gov/firearms/docs/open-letter/all-ffls-aug2008-open-letter-guidelines-natural-disasters/download

--- a/atf_eregs/templates/regulations/sidebar/atf-resources.html
+++ b/atf_eregs/templates/regulations/sidebar/atf-resources.html
@@ -23,10 +23,10 @@
           <ul>
             {% for entry in group.entries %}
               <li>
-                {% if entry.id %}
-                  <span class="entry-id">{{ entry.id }}</span>
+                {% if entry.identifier %}
+                  <span class="entry-id">{{ entry.identifier }}</span>
                 {% endif %}
-                {% external_link url=entry.url text=entry.title %}
+                {% external_link url=entry.url text=entry.short_title %}
               </li>
             {% endfor %}
           </ul>

--- a/atf_eregs/tests/sidebar_tests.py
+++ b/atf_eregs/tests/sidebar_tests.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from mock import Mock
 
-from atf_eregs.sidebar import Rulings
+from atf_eregs.sidebar import ATFResources, Rulings
 
 
 class RulingsTest(TestCase):
@@ -39,3 +39,38 @@ class RulingsTest(TestCase):
         results = Rulings("200-2", "version").context(http_client, None)
         self.assertEqual(results,
                          {"rulings": [{"id": 3}, {"id": 2}, {"id": 1}]})
+
+
+def test_atf_resources():
+    """Integration test to verify that data gets transformed correctly."""
+    # We'll use numbers as placeholders for entity content
+    http_client = Mock()
+    http_client.layer.return_value = {
+        '111-22': {'Ruling': [1, 2, 3], 'FAQ': [4, 5], 'Other Thing': [6]},
+        '111-22-c': {'FAQ': [7, 8], 'Another': [9, 10, 11]},
+        '111-33': {'Ruling': [12]},
+    }
+    resources = ATFResources('111-22', 'vvvv')
+
+    context = resources.context(http_client, request=Mock())
+
+    assert context == {
+        'count': 3 + 2 + 1 + 2 + 3,
+        'groups': [
+            {'name': 'Ruling', 'count': 3, 'entries': [1, 2, 3]},
+            {'name': 'FAQ', 'count': 2 + 2, 'entries': [4, 5, 7, 8]},
+            {'name': 'Another', 'count': 3, 'entries': [9, 10, 11]},
+            {'name': 'Other Thing', 'count': 1, 'entries': [6]},
+        ]
+    }
+
+
+def test_atf_resources_empty():
+    """We need to account for empty data."""
+    http_client = Mock()
+    http_client.layer.return_value = None
+    resources = ATFResources('111-22', 'vvvv')
+
+    context = resources.context(http_client, request=Mock())
+
+    assert context == {'count': 0, 'groups': []}


### PR DESCRIPTION
This builds on #521 to use realistic data. It encodes a sample data file into Yaml (to create what we're anticipating from the ATF API), and uses that to send data to the UI.