### PR TITLE
Build the UI in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: circleci-setup
           command: |
-            docker create -v /usr/src/app -v /usr/src/app/.venv --name holder python:3.6.2
+            docker create -v /usr/src/app -v /usr/src/app/.venv -v /usr/src/app/frontend_build/node_modules --name holder python:3.6.2
             docker cp . holder:/usr/src/app
             docker start holder
       # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,16 @@ jobs:
       # run tests!
       - run:
           name: run tests
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
           command: |
-            docker-compose -f docker-compose-circle.yml run flake8 atf_eregs
-            docker-compose -f docker-compose-circle.yml run py.test atf_eregs/tests
+            docker-compose run flake8 atf_eregs
+            docker-compose run py.test atf_eregs/tests
+      - run:
+          name: smoke test for building the frontend
+          environment:
+            COMPOSE_FILE: docker-compose-circle.yml
+          command: ./devops/compile_frontend.sh build-dist
 
       - store_artifacts:
           path: test-reports

--- a/devops/combine_frontend_sources.sh
+++ b/devops/combine_frontend_sources.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Steps that combine frontend code from -site and atf in preparation for compilation
+# This should be ran inside one of the Python containers
+set -e
+shopt -s dotglob
+
+# We don't want to use --clear as we don't want to delete node_modules
+rm -rf frontend_build/config frontend_build/regulations
+rm -rf compiled/regulations
+./devops/activate_then ./manage.py collectstatic --no-default-ignore --noinput > /dev/null
+# Copy config values
+cp frontend_build/config/* frontend_build/

--- a/devops/compile_frontend.sh
+++ b/devops/compile_frontend.sh
@@ -9,7 +9,6 @@ fi
 
 # We don't want to use --clear as we don't want to delete node_modules
 rm -rf frontend_build/config frontend_build/regulations
-mkdir -p compiled
 rm -rf compiled/regulations
 docker-compose run --rm manage.py collectstatic --no-default-ignore --noinput > /dev/null
 # Copy config values

--- a/devops/compile_frontend.sh
+++ b/devops/compile_frontend.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 if [ -z "$1" ]; then
@@ -7,14 +6,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-# We don't want to use --clear as we don't want to delete node_modules
-rm -rf frontend_build/config frontend_build/regulations
-rm -rf compiled/regulations
-docker-compose run --rm manage.py collectstatic --no-default-ignore --noinput > /dev/null
-# Copy config values
-cp frontend_build/config/.babelrc frontend_build/
-cp frontend_build/config/Gruntfile.js frontend_build/
-cp frontend_build/config/package.json frontend_build/
+docker-compose run --rm dev ./devops/combine_frontend_sources.sh
 # Build
 docker-compose run --rm grunt $1
-cp -r frontend_build/regulations compiled/regulations
+docker-compose run --rm dev cp -r frontend_build/regulations compiled/regulations

--- a/docker-compose-circle.yml
+++ b/docker-compose-circle.yml
@@ -77,9 +77,8 @@ services:
 
   grunt:
     image: node:6
-    volumes:
-      - $PWD:/usr/src/app
-      - npm_libs:/usr/src/app/frontend_build/node_modules/
+    volumes_from:
+        - container:holder
     working_dir: /usr/src/app/frontend_build/
     entrypoint: ../devops/deps_ok_then ./node_modules/.bin/grunt
 


### PR DESCRIPTION
For now, building the frontend in Circle acts as a smoke test that we haven't broken anything. Soon, we'll use the UI when deploying.

As Circle doesn't allow mounting the local file system, this moves logic around a little bit. We had had a `compile_frontend.sh` script running in the host, shuttling files around. This moves those steps into a container so they'll run in Circle (and locally).