### PR TITLE
Start "Related documents" groups collapsed.

### DIFF
--- a/atf_eregs/templates/regulations/sidebar/atf-resources.html
+++ b/atf_eregs/templates/regulations/sidebar/atf-resources.html
@@ -6,7 +6,7 @@
     </header>
     <div class="list-container">
       {% for group in groups %}
-        <header class="expandable open{% if forloop.first %} first{% endif %}">
+        <header class="expandable{% if forloop.first %} first{% endif %}">
           <h5 tabindex="0">
             <strong>{{ group.count }}</strong> {{ group.name }}{{ group.count|pluralize }}
           </h5>
@@ -14,7 +14,7 @@
             <span class="icon-text">Show/Hide Contents</span>
           </a>
         </header>
-        <div class="chunk expand-drawer">
+        <div class="chunk expand-drawer start-collapsed">
           {% if group.name == "Ruling" %}
             <p class="explanation">
               These rulings help to interpret this section of the regulation.


### PR DESCRIPTION
We reuse the existing JS logic to start this content closed; it already
degrades for non-JS users nicely.

JS users see
<img width="556" alt="screen shot 2017-08-16 at 10 38 56 am" src="https://user-images.githubusercontent.com/326918/29368943-24ce2422-826f-11e7-9972-b03d483fb7da.png">

Non-JS users see
<img width="546" alt="screen shot 2017-08-16 at 10 40 00 am" src="https://user-images.githubusercontent.com/326918/29369006-522be33c-826f-11e7-81e9-be416550efc8.png">

Should resolve #500 