### PR TITLE
Add new domain to cloud.gov manifest.

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -3,4 +3,5 @@ inherit: manifest_base.yml
 routes:
   - route: atf-eregs.18f.gov
   - route: atf-eregs.app.cloud.gov
+  - route: regulations.atf.gov
 instances: 5


### PR DESCRIPTION
We hadn't actually deployed to production after adding the regulations.atf.gov
domain, so we were missing a route in the production manifest.