### PR TITLE
Ignore the term “states” in 478 when it's part of “United States”.

### DIFF
--- a/eregs_extensions/atf_regparser/term_defs/__init__.py
+++ b/eregs_extensions/atf_regparser/term_defs/__init__.py
@@ -8,6 +8,9 @@ term_defs = {
 }
 
 ignores = {
+    "478": [
+        "United States",  # exclude "states"
+    ],
     "479": [
         u"make such return",  # exclude "make"
         u"make returns",  # exclude "make"


### PR DESCRIPTION
Some definitions /
Aren't always relevant. /
Just look straight ahead.

Addresses #536 via an exclusion for “United States” when adding term definitions to 478.