### PR TITLE
Pull in upstream, add styles for effective date

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "eregs_libs/regulations-site"]
 	path = eregs_libs/regulations-site
 	url = https://github.com/eregs/regulations-site.git
-	branch = 8.2.0
+	branch = 8.3.0
 [submodule "eregs_libs/regulations-core"]
 	path = eregs_libs/regulations-core
 	url = https://github.com/eregs/regulations-core.git

--- a/atf_eregs/static/regulations/css/scss/module/custom/_header.scss
+++ b/atf_eregs/static/regulations/css/scss/module/custom/_header.scss
@@ -30,9 +30,18 @@
     color: $atf_main_head_hover_color;
 }
 .sub-head {
-    background: $atf_sub_head_background;
+    background-color: $atf_sub_head_background;
     color: $atf_sub_head_text_color;
     line-height: 34px;
+
+    &.non-current {
+      background-color: $alert_color;
+      color: $atf_sub_head_background;
+    }
+
+    .return-to-current {
+      color: $atf_sub_head_background;
+    }
 }
 .app-nav {
     a:link,

--- a/devops/deps_ok_then
+++ b/devops/deps_ok_then
@@ -2,13 +2,18 @@
 
 if [ ! -x node_modules/.bin/deps-ok ]; then
   npm install deps-ok --quiet
-  # should this be part of -site?
-  npm install grunt-cli --quiet
 fi
 
 ./node_modules/.bin/deps-ok &> /dev/null
 if [ $? -ne 0 ]; then
   npm install --quiet
 fi
+
+# work around for eregs/regulations-site#508
+if [ ! -x node_modules/.bin/grunt ]; then
+  npm install grunt-cli --quiet
+fi
+
+
 
 exec "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ psycopg2==2.7.3
 pyelasticsearch==1.4
 pytz==2017.2              # via django
 regcore==4.2.0
-regulations==8.2.0
+regulations==8.3.0
 requests==2.18.2          # via regulations
 simplejson==3.10.0        # via pyelasticsearch
 six==1.10.0               # via furl, orderedmultidict, pyelasticsearch, regcore, regulations


### PR DESCRIPTION
This should resolve #384,  #472, #510, #514, #516 by pulling in the latest version of `regulations`.

Effective date looks like

<img width="1238" alt="screen shot 2017-08-30 at 1 31 50 pm" src="https://user-images.githubusercontent.com/326918/29886549-74714eea-8d88-11e7-8a57-101c24f39886.png">

<img width="1242" alt="screen shot 2017-08-30 at 1 31 41 pm" src="https://user-images.githubusercontent.com/326918/29886550-74723760-8d88-11e7-8681-ecc0f62e3fd8.png">
