### PR TITLE
Copy changes to home page

### DIFF
--- a/atf_eregs/templates/regulations/generic_universal.html
+++ b/atf_eregs/templates/regulations/generic_universal.html
@@ -23,7 +23,7 @@
 
       <p>
         Use this site to find, read, and understand ATF regulations.
-        Features include inline definition of terms, view for comparing
+        Features include inline definition of terms, views for comparing
         revisions, and curated links to related documents.
       </p>
 

--- a/atf_eregs/templates/regulations/generic_universal.html
+++ b/atf_eregs/templates/regulations/generic_universal.html
@@ -1,0 +1,38 @@
+{% extends "regulations/generic_universal.html" %}
+
+{% block title %} ATF eRegulations {% endblock %}
+
+
+{% block hero %}
+<div class="hero">
+    <div class="inner-wrap group">
+      <div class="primary">
+        <h2 class="hero-header">ATF Title 27 regulations</h2>
+        <p class="hero-text">Find, read, and understand ATF regulations</p>
+
+        <p class="read-more-link"><a href="{% url 'about' %}" class="go">How to use this site</a></p>
+      </div>
+    </div> <!-- /.inner-wrap -->
+</div> <!-- /.hero -->
+{% endblock %}
+
+{% block about-eregs %}
+  <section class="about bump group">
+    <h2 class="light-header">About eRegulations</h2>
+    <div class="content-primary column-l">
+
+      <p>
+        Use this site to find, read, and understand ATF regulations.
+        Features include inline definition of terms, view for comparing
+        revisions, and curated links to related documents.
+      </p>
+
+      <p><a href="{% url 'about' %}" class="go">Learn more about these features</a></p>
+    </div> <!-- /.primart -->
+
+    {% block orgcontact %}
+    {% endblock %}
+    {% block legal %}
+    {% endblock %}
+  </section> <!-- /.about -->
+{% endblock %}

--- a/atf_eregs/templates/regulations/main-header.html
+++ b/atf_eregs/templates/regulations/main-header.html
@@ -2,7 +2,7 @@
     <div class="title">
         {% spaceless %}
         <h1 class="site-title">
-          <a href="{% url 'universal_landing' %}"><span class="e">e</span>Regulations</a>
+          <a href="{% url 'universal_landing' %}">ATF <span class="e">e</span>Regulations</a>
         </h1>
         {% endspaceless %}
         {% if meta.cfr_title_number %}


### PR DESCRIPTION
Not everything is /
About us; the ants and birds /
Toil on in the sun.

Changes the home page to be less about eRegs and more about ATF-specific aspects. Also changes the upper-left text on every page from “eRegulations” to “ATF eRegulations”.