### PR TITLE
Remove Elastic libs, limit cache timeout

### DIFF
--- a/atf_eregs/settings/prod.py
+++ b/atf_eregs/settings/prod.py
@@ -25,16 +25,6 @@ HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')
 
 ALLOWED_HOSTS = ['localhost'] + env.uris
 
-# Service name may well change in the future. Fuzzy match
-elastic_service = env.get_service(name=re.compile('search'))
-if elastic_service:
-    HAYSTACK_CONNECTIONS['default'] = {
-        'ENGINE': ('haystack.backends.elasticsearch_backend.'
-                   'ElasticsearchSearchEngine'),
-        'URL': elastic_service.credentials['uri'],
-        'INDEX_NAME': 'eregs',
-    }
-
 try:
     from local_settings import *    # noqa
 except ImportError:

--- a/atf_eregs/settings/prod.py
+++ b/atf_eregs/settings/prod.py
@@ -3,7 +3,17 @@ import re
 from cfenv import AppEnv
 
 from .base import *  # noqa
-from .base import HAYSTACK_CONNECTIONS  # explicitly referenced below
+from .base import CACHES, HAYSTACK_CONNECTIONS  # explicitly referenced below
+
+def _limit_caches(max_timeout):
+    """While the regulation content doesn't change often, we want to allow ATF
+    to update their "Related Documents" relatively quickly."""
+    for cache in CACHES.values():
+        current_timeout = cache.get('TIMEOUT', 300)     # Django's default
+        cache['TIMEOUT'] = min(current_timeout, max_timeout)
+
+_limit_caches(60*60)    # 1 hour
+
 
 DEBUG = False
 TEMPLATE_DEBUG = False
@@ -24,6 +34,7 @@ HTTP_AUTH_USER = env.get_credential('HTTP_AUTH_USER')
 HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')
 
 ALLOWED_HOSTS = ['localhost'] + env.uris
+
 
 try:
     from local_settings import *    # noqa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - 9000:9000
     environment: &PROD_ENV
       PORT: 9000
-      DJANGO_SETTINGS_MODULE: atf_eregs.settings.base
+      DJANGO_SETTINGS_MODULE: atf_eregs.settings.prod
       DATABASE_URL: postgres://postgres@persistent_db/postgres
       USE_LIVE_DATA: "true"
       TMPDIR: /tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       <<: *PROD_ENV
       DEBUG: "true"
       PORT: 8000
+      DJANGO_SETTINGS_MODULE: atf_eregs.settings.dev
     volumes:
       - $PWD:/usr/src/app
       - dev_libs:/usr/src/app/.venv/

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,9 @@
 cfenv
 dj-database-url
-django-haystack
 django-overextends
 gunicorn
 newrelic
 psycopg2
-pyelasticsearch
 regcore
 regulations
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,13 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 cached-property==1.3.0    # via regcore, regulations
-certifi==2017.4.17        # via pyelasticsearch, requests
+certifi==2017.4.17        # via requests
 cfenv==0.5.3
 chardet==3.0.4            # via requests
 dj-database-url==0.4.2
-django-haystack==2.6.1
 django-mptt==0.8.7        # via regcore
 django-overextends==0.4.3
-django==1.11.3            # via django-haystack, django-overextends, regcore, regulations
-elasticsearch==1.9.0      # via pyelasticsearch
+django==1.11.3            # via django-overextends, regcore, regulations
 enum34==1.1.6             # via regulations
 furl==1.0.0               # via cfenv
 futures==3.1.1            # via regulations
@@ -24,13 +22,11 @@ marshmallow==2.13.5       # via webargs
 newrelic==2.88.1.73
 orderedmultidict==0.7.11  # via furl
 psycopg2==2.7.3
-pyelasticsearch==1.4
 pytz==2017.2              # via django
 regcore==4.2.0
 regulations==8.3.0
 requests==2.18.2          # via regulations
-simplejson==3.10.0        # via pyelasticsearch
-six==1.10.0               # via furl, orderedmultidict, pyelasticsearch, regcore, regulations
-urllib3==1.22             # via elasticsearch, pyelasticsearch, requests
+six==1.10.0               # via furl, orderedmultidict, regcore, regulations
+urllib3==1.22             # via requests
 webargs==1.8.1            # via regcore
 whitenoise==3.3.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,11 +12,9 @@ certifi==2017.4.17
 cfenv==0.5.3
 chardet==3.0.4
 dj-database-url==0.4.2
-django-haystack==2.6.1
 django-mptt==0.8.7
 django-overextends==0.4.3
 django==1.11.3
-elasticsearch==1.9.0
 enum34==1.1.6
 flake8==3.3.0
 furl==1.0.0
@@ -36,14 +34,12 @@ pbr==3.1.1                # via mock, stevedore
 psycopg2==2.7.3
 py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8
-pyelasticsearch==1.4
 pyflakes==1.5.0           # via flake8
 pytest-django==3.1.2
 pytest==3.1.3
 pytz==2017.2
 pyyaml==3.12              # via bandit
 requests==2.18.2
-simplejson==3.10.0
 six==1.10.0
 smmap2==2.0.3             # via gitdb2
 stevedore==1.25.0         # via bandit


### PR DESCRIPTION
These two tweaks aren't really related other than being referenced in the same settings file.

This removes Elastic libraries as they are not needed any longer (we switched to Postgres for full-text search).

It also limits the cache timeout to an hour (to ensure relatively quick turn around for ATF data updates).