### PR TITLE
Capital R

### DIFF
--- a/atf_eregs/templates/regulations/generic_universal.html
+++ b/atf_eregs/templates/regulations/generic_universal.html
@@ -7,7 +7,7 @@
 <div class="hero">
     <div class="inner-wrap group">
       <div class="primary">
-        <h2 class="hero-header">ATF Title 27 regulations</h2>
+        <h2 class="hero-header">ATF Title 27 Regulations</h2>
         <p class="hero-text">Find, read, and understand ATF regulations</p>
 
         <p class="read-more-link"><a href="{% url 'about' %}" class="go">How to use this site</a></p>
@@ -18,7 +18,7 @@
 
 {% block about-eregs %}
   <section class="about bump group">
-    <h2 class="light-header">About eRegulations</h2>
+    <h2 class="light-header">About ATF eRegulations</h2>
     <div class="content-primary column-l">
 
       <p>


### PR DESCRIPTION
Technically correct /
Isn't always the best kind /
Of correct: big “R”.

Tweak homepage copy: capital R in title, “About ATF eRegulations” for “about” subheading.