### PR TITLE
Stagger deploys.

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -28,7 +28,7 @@ applications:
     instances: 1
     health-check-type: process
     # Note, time on server is UTC
-    command: python redeploy.py 03:45
+    command: python redeploy.py $DEPLOY_TIME
     path: redeployer
     services:
       - redeployer-creds  # API_TOKEN

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -2,5 +2,6 @@
 inherit: manifest_base.yml
 env:
   CIRCLE_BRANCH: master
+  DEPLOY_TIME: 04:45
 routes:
   - route: atf-eregs-demo.app.cloud.gov

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -2,6 +2,7 @@
 inherit: manifest_base.yml
 env:
   CIRCLE_BRANCH: release
+  DEPLOY_TIME: 03:45
 routes:
   - route: atf-eregs.18f.gov
   - route: atf-eregs.app.cloud.gov


### PR DESCRIPTION
We share a cloud.gov memory allocation between our dev and prod environments.
Right now, we have 512M free to work with so that we can perform blue-green
deploys. Unfortunately, this means that when dev and prod environments deploy
at the same time, they _both_ try to eat that 512M, leading one to fail.

This resolves by staggering their auto-deployment by one hour.