### PR TITLE
Update ATF API URL to 1.1.

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -105,7 +105,7 @@ LOGGING = {
 # "good"). Set the cutoff to 1e-20 so that we only return better results.
 PG_SEARCH_RANK_CUTOFF = 1e-20
 
-ATF_API = 'https://www.atf.gov/api/v1.0/ereg/{cfr_part}'
+ATF_API = 'https://www.atf.gov/api/v1.1/ereg/{cfr_part}'
 
 
 if DEBUG:


### PR DESCRIPTION
TLAs for days.
ATF goes one point one.
We should do the same.

Updates the URL we use for the ATF related document API to `1.1`.

This PR uses their production URL. This should not be merged until we've tested their staging URL (which we don't have yet).