### PR TITLE
Update ATF API URL to point to their demo server, version 1.1

### DIFF
--- a/atf_eregs/settings/base.py
+++ b/atf_eregs/settings/base.py
@@ -105,7 +105,7 @@ LOGGING = {
 # "good"). Set the cutoff to 1e-20 so that we only return better results.
 PG_SEARCH_RANK_CUTOFF = 1e-20
 
-ATF_API = 'https://www.atf.gov/api/v1.0/ereg/{cfr_part}'
+ATF_API = 'https://atfstg.prod.acquia-sites.com/api/v1.1/ereg/{cfr_part}'
 
 
 if DEBUG:


### PR DESCRIPTION
Test on demo site
Before testing production.
So say the seagulls.

Once we merge this to master we can see how the new URL works on demo.